### PR TITLE
[CMake] Refresh LSP on `tblgen-lsp-server` build

### DIFF
--- a/src/main/kotlin/com/github/zero9178/mlirods/clion/CMakeTableGenBuildListener.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/clion/CMakeTableGenBuildListener.kt
@@ -1,0 +1,25 @@
+package com.github.zero9178.mlirods.clion
+
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.project.Project
+import com.jetbrains.cidr.execution.build.CidrBuildEvent
+import com.jetbrains.cidr.execution.build.CidrBuildListener
+import com.jetbrains.cidr.execution.build.CidrBuildResult
+import com.github.zero9178.mlirods.lsp.restartTableGenLSPAsync
+import com.jetbrains.cidr.cpp.cmake.model.CMakeConfiguration
+import com.jetbrains.cidr.execution.build.CidrBuildTaskType
+
+/**
+ * Checks whether 'tblgen-lsp-server' has been rebuilt and if yes, restarts the server.
+ */
+class CMakeTableGenBuildListener(private val project: Project) : CidrBuildListener {
+    override fun afterFinished(buildEvent: CidrBuildEvent, result: CidrBuildResult) {
+        if (!result.succeeded || buildEvent.taskType != CidrBuildTaskType.BUILD) return
+
+        val cmakeConfiguration = buildEvent.buildConfiguration as? CMakeConfiguration ?: return
+        if (!cmakeConfiguration.target.isTableGenLspServer) return
+
+        thisLogger().info("Restarting LSP due to rebuild")
+        restartTableGenLSPAsync(project)
+    }
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/clion/CMakeTableGenLspServerSupportProvider.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/clion/CMakeTableGenLspServerSupportProvider.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.platform.lsp.api.LspServerSupportProvider
+import com.jetbrains.cidr.cpp.cmake.model.CMakeTarget
 import com.jetbrains.cidr.cpp.cmake.workspace.CMakeWorkspace
 
 internal class CMakeTableGenLspServerSupportProvider : TableGenLspServerSupportProviderInterface {
@@ -15,9 +16,8 @@ internal class CMakeTableGenLspServerSupportProvider : TableGenLspServerSupportP
         file: VirtualFile,
         serverStarter: LspServerSupportProvider.LspServerStarter
     ): Boolean {
-        val target = project.service<CMakeWorkspace>().modelTargets.firstOrNull {
-            it.isExecutable && it.name == "tblgen-lsp-server"
-        } ?: return false
+        val target =
+            project.service<CMakeWorkspace>().modelTargets.firstOrNull(CMakeTarget::isTableGenLspServer) ?: return false
 
         val activeConfig = project.service<CMakeActiveProfileService>().fetchProfile()
         val buildConfig = target.buildConfigurations.find {

--- a/src/main/kotlin/com/github/zero9178/mlirods/clion/Utils.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/clion/Utils.kt
@@ -1,0 +1,9 @@
+package com.github.zero9178.mlirods.clion
+
+import com.jetbrains.cidr.cpp.cmake.model.CMakeTarget
+
+/**
+ * Returns true if this cmake target refers to 'tblgen-lsp-server'.
+ */
+val CMakeTarget.isTableGenLspServer: Boolean
+    get() = isExecutable && name == "tblgen-lsp-server"

--- a/src/main/resources/META-INF/com.github.zero9178.mlirods-clion.xml
+++ b/src/main/resources/META-INF/com.github.zero9178.mlirods-clion.xml
@@ -3,4 +3,8 @@
         <tableGenServerSupportProvider
                 implementation="com.github.zero9178.mlirods.clion.CMakeTableGenLspServerSupportProvider"/>
     </extensions>
+    <projectListeners>
+        <listener class="com.github.zero9178.mlirods.clion.CMakeTableGenBuildListener"
+                  topic="com.jetbrains.cidr.execution.build.CidrBuildListener"/>
+    </projectListeners>
 </idea-plugin>


### PR DESCRIPTION
This is a much more reliable method than using file listeners that is currently used. The latter will be removed soon.