### PR TITLE
Remove uses of `@Internal` APIs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask
 
 plugins {
     id("java") // Java support
@@ -102,6 +103,13 @@ intellijPlatform {
     }
 
     pluginVerification {
+        failureLevel = listOf(
+            VerifyPluginTask.FailureLevel.COMPATIBILITY_PROBLEMS,
+            VerifyPluginTask.FailureLevel.INTERNAL_API_USAGES,
+            VerifyPluginTask.FailureLevel.OVERRIDE_ONLY_API_USAGES,
+            VerifyPluginTask.FailureLevel.NON_EXTENDABLE_API_USAGES,
+        )
+
         ides {
             select {
                 types = listOf(IntelliJPlatformType.IntellijIdeaUltimate, IntelliJPlatformType.CLion)

--- a/src/main/kotlin/com/github/zero9178/mlirods/clion/CMakeActiveProfileService.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/clion/CMakeActiveProfileService.kt
@@ -6,7 +6,7 @@ import com.intellij.execution.ExecutionTargetManager
 import com.intellij.execution.RunManager
 import com.intellij.execution.RunManagerListener
 import com.intellij.openapi.components.Service
-import com.intellij.openapi.components.serviceAsync
+import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.progress.runBlockingCancellable
 import com.intellij.openapi.project.Project
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicReference
 class CMakeActiveProfileService(project: Project, cs: CoroutineScope) {
 
     private var myProfile: Deferred<String> by AtomicReference(cs.async {
-        val connection = project.messageBus.simpleConnect()
+        val connection = project.messageBus.connect(this)
         try {
             suspendCancellableCoroutine { cont ->
                 connection.subscribe(RunManagerListener.TOPIC, object : RunManagerListener {
@@ -36,7 +36,7 @@ class CMakeActiveProfileService(project: Project, cs: CoroutineScope) {
             connection.disconnect()
         }
 
-        val manager = project.serviceAsync<ExecutionTargetManager>()
+        val manager = project.service<ExecutionTargetManager>()
         val target = manager.activeTarget
         (target as? CMakeBuildProfileExecutionTarget)?.profileName ?: ""
     })


### PR DESCRIPTION
Plugins with internal API uses are not publishable due to the instability guarantees. This PR removes all uses of such methods