### PR TITLE
[CMake] Fix race condition and cancellations at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ## [Unreleased]
 ### Added
 
+### Fixed
+- Possible race conditions and cancellations on project startup leading to the LSP not being started.
+
 ## [0.0.1] - 2024-12-27
 ### Added
 - Support for using `tblgen-lsp-server` built as part of the opened CMake project

--- a/src/main/resources/META-INF/com.github.zero9178.mlirods-clion.xml
+++ b/src/main/resources/META-INF/com.github.zero9178.mlirods-clion.xml
@@ -10,5 +10,9 @@
     <projectListeners>
         <listener class="com.github.zero9178.mlirods.clion.CMakeTableGenBuildListener"
                   topic="com.jetbrains.cidr.execution.build.CidrBuildListener"/>
+        <listener class="com.github.zero9178.mlirods.clion.RunManagerInitializedListener"
+                  topic="com.intellij.execution.RunManagerListener"/>
+        <listener class="com.github.zero9178.mlirods.clion.CMakeExecutionTargetListener"
+                  topic="com.intellij.execution.ExecutionTargetListener"/>
     </projectListeners>
 </idea-plugin>


### PR DESCRIPTION
The current implementation of fetching the cmake build profile has two large issues:
* Since service initialization is lazy, the listeners may only start receiving events as soon as the service is requested for the first time
* Since the implementation used a cancellable blocking coroutine await, it is likely to be cancelled and needs an explicit restart

The new implementation leverages the declarative listeners to fix the first issue. It guarantees that the given listener classes will receive the events by lazy initializing them on first publish. Additionally, the LSP is restarted once the run manager is initialized and the cmake build profile known.