### PR TITLE
[TableGen] Add basic file type and lexer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .intellijPlatform
 .qodana
 build
+gen/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # MLIR ODS Changelog
 
 ## [Unreleased]
+### Added
+- Initial file type and syntax highlighting support
 
 ## [0.0.2] - 2025-01-01
 ### Fixed

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ intelliJPlatform = "2.2.1"
 kotlin = "2.1.0"
 kover = "0.9.0"
 qodana = "2024.3.4"
+grammarKit = "2022.3.2.2"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -18,3 +19,4 @@ intelliJPlatform = { id = "org.jetbrains.intellij.platform", version.ref = "inte
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 qodana = { id = "org.jetbrains.qodana", version.ref = "qodana" }
+grammarKit = { id = "org.jetbrains.grammarkit", version.ref = "grammarKit" }

--- a/src/main/kotlin/com/github/zero9178/mlirods/MyIcons.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/MyIcons.kt
@@ -1,0 +1,8 @@
+package com.github.zero9178.mlirods
+
+import com.intellij.openapi.util.IconLoader
+
+object MyIcons {
+    @JvmField
+    val TableGenIcon = IconLoader.getIcon("/icons/tablegen-file.svg", javaClass)
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/highlighting/TableGenSyntaxHighlighter.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/highlighting/TableGenSyntaxHighlighter.kt
@@ -1,0 +1,39 @@
+package com.github.zero9178.mlirods.highlighting
+
+import com.github.zero9178.mlirods.language.TableGenLexerAdapter
+import com.github.zero9178.mlirods.language.generated.TableGenTypes
+import com.intellij.lexer.Lexer
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.fileTypes.SyntaxHighlighterBase
+import com.intellij.psi.tree.IElementType
+
+internal class TableGenSyntaxHighlighter : SyntaxHighlighterBase() {
+
+    /**
+     * Returns the lexer used for highlighting the file. The lexer is invoked incrementally when the file is changed, so it must be
+     * capable of saving/restoring state and resuming lexing from the middle of the file.
+     *
+     * @return The lexer implementation.
+     */
+    override fun getHighlightingLexer(): Lexer {
+        return TableGenLexerAdapter()
+    }
+
+    /**
+     * Returns the list of text attribute keys used for highlighting the specified token type. The attributes of all attribute keys
+     * returned for the token type are successively merged to obtain the color and attributes of the token.
+     *
+     * @param tokenType The token type for which the highlighting is requested.
+     * @return The array of text attribute keys.
+     */
+    override fun getTokenHighlights(tokenType: IElementType?): Array<TextAttributesKey> = when (tokenType) {
+        TableGenTypes.STRING_LITERAL -> arrayOf(DefaultLanguageHighlighterColors.STRING)
+        TableGenTypes.INTEGER -> arrayOf(DefaultLanguageHighlighterColors.NUMBER)
+        TableGenTypes.BLOCK_COMMENT -> arrayOf(DefaultLanguageHighlighterColors.BLOCK_COMMENT)
+        TableGenTypes.LINE_COMMENT -> arrayOf(DefaultLanguageHighlighterColors.LINE_COMMENT)
+        TableGenTypes.LBRACE, TableGenTypes.RBRACE -> arrayOf(DefaultLanguageHighlighterColors.BRACES)
+        TableGenTypes.DEF -> arrayOf(DefaultLanguageHighlighterColors.KEYWORD)
+        else -> emptyArray()
+    }
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/TableGen.bnf
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/TableGen.bnf
@@ -1,0 +1,41 @@
+{
+  parserClass="com.github.zero9178.mlirods.language.generated.TableGenParser"
+
+  extends="com.intellij.extapi.psi.ASTWrapperPsiElement"
+
+  psiClassPrefix="TableGen"
+  psiImplClassSuffix="Impl"
+  psiPackage="com.github.zero9178.mlirods.language.generated.psi"
+  psiImplPackage="com.github.zero9178.mlirods.language.generated.psi.impl"
+
+  elementTypeHolderClass="com.github.zero9178.mlirods.language.generated.TableGenTypes"
+  elementTypeClass="com.github.zero9178.mlirods.language.TableGenElementType"
+  tokenTypeClass="com.github.zero9178.mlirods.language.TableGenTokenType"
+  tokens = [
+    PLUS='+'
+    MINUS='-'
+    LBRACKET='['
+    RBRACKET=']'
+    LBRACE='{'
+    RBRACE='}'
+    LANGLE='<'
+    RANGLE='>'
+    COLON=':'
+    SEMICOLON=';'
+    DOT='.'
+    ELLIPSE='...'
+    EQUALS='='
+    QUESTION_MARK='?'
+    HASHTAG='#'
+    DEF='def'
+  ]
+}
+
+tableGenFile ::= item_*
+
+// Most accepting parser possible which simply allows a sequence of all possible token types.
+// We primarily use the parser infrastructure to auto-generate the token types which the lexer generates.
+// It could be used in the future for semantic tokens as well, although the LSP should provide these instead.
+private item_ ::= punctuation | INTEGER | LINE_COMMENT | BLOCK_COMMENT | CLRF | STRING_LITERAL | OTHER | keyword
+punctuation ::= '+' | '-' | '[' | ']' | '{' | '}' | '<' | '>' | ':' | ';' | '.' | '...' | '=' | '?' | '#'
+keyword ::= 'def'

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/TableGen.flex
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/TableGen.flex
@@ -1,0 +1,55 @@
+// Copyright 2000-2022 JetBrains s.r.o. and other contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.github.zero9178.mlirods.language.generated;
+
+import com.ibm.icu.impl.UResource;import com.intellij.lexer.FlexLexer;
+import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.TokenType;
+
+%%
+
+%class TableGenLexer
+%implements FlexLexer
+%unicode
+%public
+%function advance
+%type IElementType
+%eof{  return;
+%eof}
+
+CRLF=\R
+WHITE_SPACE=[\ \n\t\f]
+ESCAPES=("\\n"|"\\\\"|"\\\""|"\\t"|"\\'")
+
+%%
+("+")                                           { return TableGenTypes.PLUS; }
+("-")                                           { return TableGenTypes.MINUS; }
+("[")                                           { return TableGenTypes.LBRACKET; }
+("]")                                           { return TableGenTypes.RBRACKET; }
+("{")                                           { return TableGenTypes.LBRACE; }
+("}")                                           { return TableGenTypes.RBRACE; }
+("<")                                           { return TableGenTypes.LANGLE; }
+(">")                                           { return TableGenTypes.RANGLE; }
+(":")                                           { return TableGenTypes.COLON; }
+(";")                                           { return TableGenTypes.SEMICOLON; }
+(".")                                           { return TableGenTypes.DOT; }
+("...")                                         { return TableGenTypes.ELLIPSE; }
+("=")                                           { return TableGenTypes.EQUALS; }
+("?")                                           { return TableGenTypes.QUESTION_MARK; }
+("#")                                           { return TableGenTypes.HASHTAG; }
+
+("def")                                         { return TableGenTypes.DEF; }
+
+((\+|-)?[0-9]+)                                 { return TableGenTypes.INTEGER; }
+(0x[0-9a-fA-F]+)                                { return TableGenTypes.INTEGER; }
+(0b[01]+)                                       { return TableGenTypes.INTEGER; }
+
+(("[{")!([^]* "}]" [^]*)("}]"))                 { return TableGenTypes.STRING_LITERAL; }
+(("\"")(([^\"\r\n])|{ESCAPES})*("\""))          { return TableGenTypes.STRING_LITERAL; }
+
+(("//")[^\r\n]*)                                { return TableGenTypes.LINE_COMMENT; }
+
+({CRLF}|{WHITE_SPACE})+                         { return TokenType.WHITE_SPACE; }
+
+(("/*")!([^]* "*/" [^]*)("*/"))                 { return TableGenTypes.BLOCK_COMMENT; }
+
+[^]                                             { return TableGenTypes.OTHER; }

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/TableGenLanguage.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/TableGenLanguage.kt
@@ -1,0 +1,44 @@
+package com.github.zero9178.mlirods.language
+
+import com.github.zero9178.mlirods.MyIcons
+import com.intellij.extapi.psi.PsiFileBase
+import com.intellij.lang.Language
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.fileTypes.LanguageFileType
+import com.intellij.psi.FileViewProvider
+import javax.swing.Icon
+
+class TableGenLanguage private constructor() : Language("TableGen") {
+    companion object {
+        val INSTANCE = TableGenLanguage()
+    }
+}
+
+class TableGenFile(viewProvider: FileViewProvider) : PsiFileBase(viewProvider, TableGenLanguage.INSTANCE) {
+    override fun getFileType(): FileType = TableGenFileType.INSTANCE
+}
+
+internal class TableGenFileType : LanguageFileType(TableGenLanguage.INSTANCE) {
+
+    @Suppress("CompanionObjectInExtension")
+    companion object {
+        @JvmField
+        val INSTANCE = TableGenFileType()
+    }
+
+    override fun getName(): String {
+        return "TableGen"
+    }
+
+    override fun getDescription(): String {
+        return "LLVM TableGen langauge"
+    }
+
+    override fun getDefaultExtension(): String {
+        return "td";
+    }
+
+    override fun getIcon(): Icon {
+        return MyIcons.TableGenIcon
+    }
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/TableGenLexerAdapter.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/TableGenLexerAdapter.kt
@@ -1,0 +1,6 @@
+package com.github.zero9178.mlirods.language
+
+import com.github.zero9178.mlirods.language.generated.TableGenLexer
+import com.intellij.lexer.FlexAdapter
+
+class TableGenLexerAdapter : FlexAdapter(TableGenLexer(null))

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/TableGenParserDefinition.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/TableGenParserDefinition.kt
@@ -1,0 +1,32 @@
+package com.github.zero9178.mlirods.language
+
+import com.intellij.lang.ASTNode
+import com.intellij.lang.ParserDefinition
+import com.intellij.lexer.Lexer
+import com.intellij.openapi.project.Project
+import com.intellij.psi.FileViewProvider
+import com.intellij.psi.PsiElement
+import com.intellij.psi.tree.IFileElementType
+import com.intellij.psi.tree.TokenSet
+import com.github.zero9178.mlirods.language.generated.TableGenTypes
+import com.github.zero9178.mlirods.language.generated.TableGenParser
+
+private val FILE = IFileElementType(TableGenLanguage.INSTANCE)
+private val COMMENTS = TokenSet.create(TableGenTypes.LINE_COMMENT, TableGenTypes.BLOCK_COMMENT)
+private val STRING_LITERALS = TokenSet.create(TableGenTypes.STRING_LITERAL)
+
+internal class TableGenParserDefinition : ParserDefinition {
+    override fun createLexer(project: Project?): Lexer = TableGenLexerAdapter()
+
+    override fun createParser(project: Project?) = TableGenParser()
+
+    override fun getFileNodeType() = FILE
+
+    override fun getCommentTokens(): TokenSet = COMMENTS
+
+    override fun getStringLiteralElements(): TokenSet = STRING_LITERALS
+
+    override fun createElement(node: ASTNode?): PsiElement = TableGenTypes.Factory.createElement(node)
+
+    override fun createFile(viewProvider: FileViewProvider) = TableGenFile(viewProvider)
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/TableGenTokens.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/TableGenTokens.kt
@@ -1,0 +1,10 @@
+package com.github.zero9178.mlirods.language
+
+import com.intellij.psi.tree.IElementType
+import com.intellij.psi.tree.TokenSet
+import org.jetbrains.annotations.NonNls
+import com.github.zero9178.mlirods.language.generated.TableGenTypes
+
+class TableGenTokenType(@NonNls debugName: String) : IElementType(debugName, TableGenLanguage.INSTANCE)
+
+class TableGenElementType(@NonNls debugName: String) : IElementType(debugName, TableGenLanguage.INSTANCE)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -11,7 +11,15 @@
     <resource-bundle>messages.MyBundle</resource-bundle>
 
     <extensions defaultExtensionNs="com.intellij">
-
+        <fileType name="TableGen"
+                  implementationClass="com.github.zero9178.mlirods.language.TableGenFileType"
+                  fieldName="INSTANCE"
+                  language="TableGen"
+                  extensions="td"/>
+        <lang.parserDefinition language="TableGen"
+                               implementationClass="com.github.zero9178.mlirods.language.TableGenParserDefinition"/>
+        <lang.syntaxHighlighter language="TableGen"
+                                implementationClass="com.github.zero9178.mlirods.highlighting.TableGenSyntaxHighlighter"/>
     </extensions>
 
     <extensions defaultExtensionNs="com.intellij.platform.lsp">

--- a/src/main/resources/icons/tablegen-file.svg
+++ b/src/main/resources/icons/tablegen-file.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license. -->
+
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   fill="none"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   sodipodi:docname="tablegen-file.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1128"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="23.647214"
+     inkscape:cx="2.4950085"
+     inkscape:cy="2.3681437"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <rect
+     x="2.4830508"
+     y="2.4830508"
+     width="11"
+     height="11"
+     rx="1.5"
+     id="rect4"
+     style="fill:#f2f2f2;fill-opacity:1;stroke:#4d4d4d;stroke-opacity:1" />
+  <text
+     xml:space="preserve"
+     style="font-size:7.23728px;line-height:1;font-family:sans-serif;text-align:center;text-anchor:middle;stroke-width:0;stroke-dasharray:none"
+     x="8.1375074"
+     y="10.583709"
+     id="text1"><tspan
+       sodipodi:role="line"
+       id="tspan1"
+       x="8.1375074"
+       y="10.583709"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:1;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#4d4d4d;stroke-width:0;stroke-dasharray:none">TD</tspan></text>
+</svg>

--- a/src/main/resources/icons/tablegen-file_dark.svg
+++ b/src/main/resources/icons/tablegen-file_dark.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license. -->
+
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   fill="none"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   sodipodi:docname="tablegen-file_dark.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1128"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="32.255489"
+     inkscape:cx="2.5732054"
+     inkscape:cy="3.3482673"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <rect
+     x="2.4830508"
+     y="2.4830508"
+     width="11"
+     height="11"
+     rx="1.5"
+     id="rect4"
+     style="fill:#333333;fill-opacity:1;stroke:#b3b3b3;stroke-opacity:1" />
+  <text
+     xml:space="preserve"
+     style="font-size:7.23728px;line-height:1;font-family:sans-serif;text-align:center;text-anchor:middle;fill:#b3b3b3;stroke-width:0;stroke-dasharray:none"
+     x="8.1375074"
+     y="10.583709"
+     id="text1"><tspan
+       sodipodi:role="line"
+       id="tspan1"
+       x="8.1375074"
+       y="10.583709"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:1;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#b3b3b3;stroke-width:0;stroke-dasharray:none">TD</tspan></text>
+</svg>

--- a/src/test/kotlin/com/github/zero9178/mlirods/LexerTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/LexerTest.kt
@@ -1,0 +1,111 @@
+package com.github.zero9178.mlirods
+
+import com.github.zero9178.mlirods.language.TableGenLexerAdapter
+import com.intellij.testFramework.LexerTestCase
+
+class LexerTest : LexerTestCase() {
+    override fun createLexer() = TableGenLexerAdapter()
+
+    override fun getDirPath() = ""
+
+    fun `test punctuation`() = doTest(
+        """
+            +
+            -
+            [
+            ]
+            {
+            }
+            <
+            >
+            :
+            ;
+            .
+            ...
+            =
+            ?
+            #
+        """.trimMargin().filter { !it.isWhitespace() },
+        "+ ('+')\n" + "- ('-')\n" + "[ ('[')\n" + "] (']')\n" + "{ ('{')\n" + "} ('}')\n" + "< ('<')\n" + "> ('>')\n" + ": (':')\n" + "; (';')\n" + "... ('...')\n" + ". ('.')\n" + "= ('=')\n" + "? ('?')\n" + "# ('#')"
+    )
+
+    fun `test keywords`() = doTest(
+        "def", "def ('def')"
+    )
+
+    fun `test integers`() = doTest(
+        """
+        0
+        +1
+        -15
+        0xaFfE
+        0b0101
+    """.trimIndent(),
+        "INTEGER ('0')\n" +
+                "WHITE_SPACE ('\\n')\n" +
+                "INTEGER ('+1')\n" +
+                "WHITE_SPACE ('\\n')\n" +
+                "INTEGER ('-15')\n" +
+                "WHITE_SPACE ('\\n')\n" +
+                "INTEGER ('0xaFfE')\n" +
+                "WHITE_SPACE ('\\n')\n" +
+                "INTEGER ('0b0101')"
+    )
+
+    fun `test strings`() = doTest(
+        """
+       "quoted\"\n ends now"
+    """.trimIndent(),
+        "STRING_LITERAL ('\"quoted\\\"\\n ends now\"')"
+    )
+
+    fun `test strings negative`() = doTest(
+        """
+        "
+        "
+    """.trimIndent(), "OTHER ('\"')\n" +
+                "WHITE_SPACE ('\\n')\n" +
+                "OTHER ('\"')"
+    )
+
+    fun `test raw strings`() = doTest(
+        """
+       [{ some text
+       that may have
+       newlines inbetween
+       that even have "quotes" up until }]
+    """.trimIndent(),
+        "STRING_LITERAL ('[{ some text\\n" +
+                "that may have\\n" +
+                "newlines inbetween\\n" +
+                "that even have \"quotes\" up until }]')"
+    )
+
+    fun `test line comment`() = doTest(
+        """
+        // text
+        0
+    """.trimIndent(), "LINE_COMMENT ('// text')\n" +
+                "WHITE_SPACE ('\\n')\n" +
+                "INTEGER ('0')"
+    )
+
+    fun `test block comment`() = doTest(
+        """
+        /* text
+        0
+        */
+        0
+    """.trimIndent(), "BLOCK_COMMENT ('/* text\\n0\\n*/')\n" +
+                "WHITE_SPACE ('\\n')\n" +
+                "INTEGER ('0')"
+    )
+
+    fun `test block comment negative`() = doTest(
+        """
+            /*/
+    """.trimIndent(), "OTHER ('/')\n" +
+                "OTHER ('*')\n" +
+                "OTHER ('/')"
+    )
+}


### PR DESCRIPTION
This PR adds the initial skeleton needed to add syntax highlighting for TableGen in IntelliJ. To do so, a very basic lexer and parser have been implemented that never generates error tokens. The parser simply accepts every possible token kind and is used to generate the lexer token definitions. The lexer is used for the actual syntax highlighting.

More tokens will be added to the lexer in the future but the parser may be kept as simple as is reasonable. Instead, features such as [semantic tokens support](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_semanticTokens) should probably be added to the LSP instead.