### PR TITLE
[TableGen] Add commenter functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # MLIR ODS Changelog
 
 ## [Unreleased]
+### Added
+- Enabled `Comment with Line/Block Comment` functionality in TableGen
 
 ## [0.1.0] - 2025-01-03
 ### Added

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/TableGenCommenter.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/TableGenCommenter.kt
@@ -1,0 +1,15 @@
+package com.github.zero9178.mlirods.language
+
+import com.intellij.lang.Commenter
+
+private class TableGenCommenter : Commenter {
+    override fun getLineCommentPrefix() = "//"
+
+    override fun getBlockCommentPrefix() = "/*"
+
+    override fun getBlockCommentSuffix() = "*/"
+
+    override fun getCommentedBlockCommentPrefix() = null
+
+    override fun getCommentedBlockCommentSuffix() = null
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -22,6 +22,8 @@
                                 implementationClass="com.github.zero9178.mlirods.highlighting.TableGenSyntaxHighlighter"/>
         <lang.braceMatcher language="TableGen"
                            implementationClass="com.github.zero9178.mlirods.highlighting.TableGenBraceMatcher"/>
+        <lang.commenter language="TableGen"
+                        implementationClass="com.github.zero9178.mlirods.language.TableGenCommenter"/>
     </extensions>
 
     <extensions defaultExtensionNs="com.intellij.platform.lsp">

--- a/src/test/kotlin/com/github/zero9178/mlirods/CommenterTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/CommenterTest.kt
@@ -1,0 +1,33 @@
+package com.github.zero9178.mlirods
+
+
+import com.intellij.codeInsight.generation.actions.CommentByBlockCommentAction
+import com.intellij.codeInsight.generation.actions.CommentByLineCommentAction
+import com.intellij.testFramework.LightPlatformCodeInsightTestCase
+
+class CommenterTest : LightPlatformCodeInsightTestCase() {
+    fun `test line commenter`() {
+        configureFromFileText(
+            "test.td", """
+            <caret> def Foo;
+        """.trimIndent()
+        )
+        val action = CommentByLineCommentAction()
+        action.actionPerformedImpl(project, editor)
+        checkResultByText("// def Foo;")
+    }
+
+    fun `test block commenter`() {
+        configureFromFileText(
+            "test.td", """
+            <selection>def Foo;</selection>
+        """.trimIndent()
+        )
+        val action = CommentByBlockCommentAction()
+        action.actionPerformedImpl(project, editor)
+        checkResultByText(
+            "/*\n" +
+                    "def Foo;*/\n"
+        )
+    }
+}


### PR DESCRIPTION
This class is used as a simple way to enable the "Comment with Line Comment" (or block comment) action in the IDE.