### PR TITLE
[Highlighting] Implement highlighting fields in `let`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # MLIR ODS Changelog
 
 ## [Unreleased]
+### Added
+- Syntax highlighting of fields in `let`-expressions
 
 ## [0.2.0] - 2025-01-16
 ### Added

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/TableGen.bnf
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/TableGen.bnf
@@ -55,6 +55,7 @@
     STRING='string'
     THEN='then'
     TRUE='true'
+    IDENTIFIER="regexp:[0-9]*[a-zA-Z_][a-zA-Z_0-9]*"
   ]
 }
 
@@ -64,6 +65,7 @@ tableGenFile ::= item_*
 // We primarily use the parser infrastructure to auto-generate the token types which the lexer generates.
 // It could be used in the future for semantic tokens as well, although the LSP should provide these instead.
 private item_ ::= punctuation
+                | let_directive
                 | INTEGER
                 | LINE_COMMENT
                 | BLOCK_COMMENT
@@ -74,6 +76,8 @@ private item_ ::= punctuation
                 | IDENTIFIER
                 | OTHER
                 | keyword
+
+let_directive ::= 'let' IDENTIFIER
 
 punctuation ::= '+' | '-' | '[' | ']' | '{' | '}' | '<' | '>' | ':' | ';' | '.' | '...' | '=' | '?' | '#' | '(' | ')'
               | ','

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/highlighting/TableGenSemanticTokensAnnotator.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/highlighting/TableGenSemanticTokensAnnotator.kt
@@ -5,9 +5,10 @@ import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
+import com.intellij.openapi.project.DumbAware
 import com.intellij.psi.PsiElement
 
-private class TableGenSemanticTokensAnnotator : Annotator {
+private class TableGenSemanticTokensAnnotator : Annotator, DumbAware {
     override fun annotate(element: PsiElement, holder: AnnotationHolder) {
         when (element) {
             is TableGenLetDirective -> {

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/highlighting/TableGenSemanticTokensAnnotator.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/highlighting/TableGenSemanticTokensAnnotator.kt
@@ -1,0 +1,21 @@
+package com.github.zero9178.mlirods.language.highlighting
+
+import com.github.zero9178.mlirods.language.generated.psi.TableGenLetDirective
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.Annotator
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
+import com.intellij.psi.PsiElement
+
+private class TableGenSemanticTokensAnnotator : Annotator {
+    override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+        when (element) {
+            is TableGenLetDirective -> {
+                holder.newSilentAnnotation(HighlightSeverity.TEXT_ATTRIBUTES)
+                    .range(element.identifier)
+                    .textAttributes(DefaultLanguageHighlighterColors.INSTANCE_FIELD)
+                    .create()
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -26,6 +26,8 @@
                         implementationClass="com.github.zero9178.mlirods.language.TableGenCommenter"/>
         <lang.quoteHandler language="TableGen"
                            implementationClass="com.github.zero9178.mlirods.language.TableGenQuoteHandler"/>
+        <annotator language="TableGen"
+                   implementationClass="com.github.zero9178.mlirods.language.highlighting.TableGenSemanticTokensAnnotator"/>
     </extensions>
 
     <extensions defaultExtensionNs="com.intellij.platform.lsp">

--- a/src/test/kotlin/com/github/zero9178/mlirods/SemanticTokensAnnotatorTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/SemanticTokensAnnotatorTest.kt
@@ -1,0 +1,20 @@
+package com.github.zero9178.mlirods
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+class SemanticTokensAnnotatorTest : BasePlatformTestCase() {
+
+    fun `test let identifier`() {
+        myFixture.configureByText(
+            "test.td", """
+            class Foo {
+                string s = ?;
+            }
+            def Foo : Foo {
+                let <text_attr textAttributesKey="DEFAULT_INSTANCE_FIELD">s</text_attr> = "";
+            }
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting(false, true, false)
+    }
+}


### PR DESCRIPTION
This is the first instance of semantic token highlighting by using the parser to heuristically highlight identifiers that follow `let`