### PR TITLE
[Highlighting] Add custom color page for TableGen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Unreleased]
 ### Added
 - Syntax highlighting of fields in `let`-expressions
+- Color page in `Editor -> Color Scheme -> TableGen` 
 
 ## [0.2.0] - 2025-01-16
 ### Added

--- a/src/main/kotlin/com/github/zero9178/mlirods/color/TableGenColorSettingsPage.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/color/TableGenColorSettingsPage.kt
@@ -1,0 +1,68 @@
+package com.github.zero9178.mlirods.color
+
+import com.github.zero9178.mlirods.MyIcons
+import com.github.zero9178.mlirods.highlighting.TableGenSyntaxHighlighter
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.fileTypes.SyntaxHighlighter
+import com.intellij.openapi.options.colors.AttributesDescriptor
+import com.intellij.openapi.options.colors.ColorDescriptor
+import com.intellij.openapi.options.colors.ColorSettingsPage
+import com.intellij.openapi.util.NlsContexts
+import org.jetbrains.annotations.NonNls
+
+private val DESCRIPTORS = arrayOf(
+    AttributesDescriptor({ "Comments//Line comment" }, LINE_COMMENT),
+    AttributesDescriptor({ "Comments//Block comment" }, BLOCK_COMMENT),
+    AttributesDescriptor({ "Number" }, NUMBER),
+    AttributesDescriptor({ "Braces and Operators//Braces" }, BRACES),
+    AttributesDescriptor({ "Braces and Operators//Parentheses" }, PARENTHESES),
+    AttributesDescriptor({ "Braces and Operators//Brackets" }, BRACKETS),
+    AttributesDescriptor({ "Braces and Operators//Comma" }, COMMA),
+    AttributesDescriptor({ "Braces and Operators//Semicolon" }, SEMICOLON),
+    AttributesDescriptor({ "Braces and Operators//Dot" }, DOT),
+    AttributesDescriptor({ "Braces and Operators//Operators" }, OPERATION_SIGN),
+    AttributesDescriptor({ "String//Escape sequence" }, STRING_ESCAPE),
+    AttributesDescriptor({ "String//String text" }, STRING),
+    AttributesDescriptor({ "Keyword" }, KEYWORD),
+    AttributesDescriptor({ "Identifiers//Field" }, FIELD),
+    AttributesDescriptor({ "Identifiers//Other" }, IDENTIFIER),
+)
+
+private class TableGenColorSettingsPage : ColorSettingsPage {
+    override fun getIcon() = MyIcons.TableGenIcon
+
+    override fun getHighlighter(): SyntaxHighlighter {
+        return TableGenSyntaxHighlighter()
+    }
+
+    override fun getDemoText(): @NonNls String {
+        return """
+        // this a line comment
+        /*
+        this a block comment
+        */
+        class Foo<int i = 0, bit f = 0> {
+            string s = "string literal" # " after operator";
+            code c = [{
+                code literal
+            }];
+        }
+        
+        defvar b = Foo<>.s;
+        """.trimIndent()
+    }
+
+    override fun getAdditionalHighlightingTagToDescriptorMap(): Map<String?, TextAttributesKey?>? {
+        return null
+    }
+
+    override fun getAttributeDescriptors() = DESCRIPTORS
+
+    override fun getColorDescriptors(): Array<out ColorDescriptor?> {
+        return ColorDescriptor.EMPTY_ARRAY
+    }
+
+    override fun getDisplayName(): @NlsContexts.ConfigurableName String {
+        return "TableGen"
+    }
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/color/TableGenTextAttributesKeys.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/color/TableGenTextAttributesKeys.kt
@@ -1,0 +1,22 @@
+package com.github.zero9178.mlirods.color
+
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
+import com.intellij.openapi.editor.colors.TextAttributesKey.createTextAttributesKey
+
+val LINE_COMMENT = createTextAttributesKey("TABLEGEN_LINE_COMMENT", DefaultLanguageHighlighterColors.LINE_COMMENT)
+val BLOCK_COMMENT = createTextAttributesKey("TABLEGEN_BLOCK_COMMENT", DefaultLanguageHighlighterColors.BLOCK_COMMENT)
+val NUMBER = createTextAttributesKey("TABLEGEN_NUMBER", DefaultLanguageHighlighterColors.NUMBER)
+val BRACES = createTextAttributesKey("TABLEGEN_BRACES", DefaultLanguageHighlighterColors.BRACES)
+val PARENTHESES = createTextAttributesKey("TABLEGEN_PARENTHESES", DefaultLanguageHighlighterColors.PARENTHESES)
+val BRACKETS = createTextAttributesKey("TABLEGEN_BRACKETS", DefaultLanguageHighlighterColors.BRACKETS)
+val IDENTIFIER = createTextAttributesKey("TABLEGEN_IDENTIFIER", DefaultLanguageHighlighterColors.IDENTIFIER)
+val COMMA = createTextAttributesKey("TABLEGEN_COMMA", DefaultLanguageHighlighterColors.COMMA)
+val SEMICOLON = createTextAttributesKey("TABLEGEN_SEMICOLON", DefaultLanguageHighlighterColors.SEMICOLON)
+val DOT = createTextAttributesKey("TABLEGEN_DOT", DefaultLanguageHighlighterColors.DOT)
+val STRING_ESCAPE =
+    createTextAttributesKey("TABLEGEN_STRING_ESCAPE", DefaultLanguageHighlighterColors.VALID_STRING_ESCAPE)
+val KEYWORD = createTextAttributesKey("TABLEGEN_KEYWORD", DefaultLanguageHighlighterColors.KEYWORD)
+val OPERATION_SIGN = createTextAttributesKey("TABLEGEN_OPERATOR_SIGN", DefaultLanguageHighlighterColors.OPERATION_SIGN)
+val STRING = createTextAttributesKey("TABLEGEN_STRING", DefaultLanguageHighlighterColors.STRING)
+
+val FIELD = createTextAttributesKey("TABLEGEN_FIELD", DefaultLanguageHighlighterColors.INSTANCE_FIELD)

--- a/src/main/kotlin/com/github/zero9178/mlirods/highlighting/TableGenSyntaxHighlighter.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/highlighting/TableGenSyntaxHighlighter.kt
@@ -1,5 +1,19 @@
 package com.github.zero9178.mlirods.highlighting
 
+import com.github.zero9178.mlirods.color.BLOCK_COMMENT
+import com.github.zero9178.mlirods.color.BRACES
+import com.github.zero9178.mlirods.color.BRACKETS
+import com.github.zero9178.mlirods.color.COMMA
+import com.github.zero9178.mlirods.color.DOT
+import com.github.zero9178.mlirods.color.IDENTIFIER
+import com.github.zero9178.mlirods.color.KEYWORD
+import com.github.zero9178.mlirods.color.LINE_COMMENT
+import com.github.zero9178.mlirods.color.NUMBER
+import com.github.zero9178.mlirods.color.OPERATION_SIGN
+import com.github.zero9178.mlirods.color.PARENTHESES
+import com.github.zero9178.mlirods.color.SEMICOLON
+import com.github.zero9178.mlirods.color.STRING
+import com.github.zero9178.mlirods.color.STRING_ESCAPE
 import com.github.zero9178.mlirods.language.KEYWORDS
 import com.github.zero9178.mlirods.language.PUNCTUATION
 import com.github.zero9178.mlirods.language.STRING_LITERALS
@@ -31,21 +45,21 @@ internal class TableGenSyntaxHighlighter : SyntaxHighlighterBase() {
      * @return The array of text attribute keys.
      */
     override fun getTokenHighlights(tokenType: IElementType?): Array<TextAttributesKey> = when (tokenType) {
-        TableGenTypes.INTEGER -> arrayOf(DefaultLanguageHighlighterColors.NUMBER)
-        TableGenTypes.BLOCK_COMMENT -> arrayOf(DefaultLanguageHighlighterColors.BLOCK_COMMENT)
-        TableGenTypes.LINE_COMMENT -> arrayOf(DefaultLanguageHighlighterColors.LINE_COMMENT)
-        TableGenTypes.LBRACE, TableGenTypes.RBRACE -> arrayOf(DefaultLanguageHighlighterColors.BRACES)
-        TableGenTypes.LPAREN, TableGenTypes.RPAREN -> arrayOf(DefaultLanguageHighlighterColors.PARENTHESES)
-        TableGenTypes.LBRACKET, TableGenTypes.RBRACKET -> arrayOf(DefaultLanguageHighlighterColors.BRACKETS)
-        TableGenTypes.IDENTIFIER -> arrayOf(DefaultLanguageHighlighterColors.IDENTIFIER)
-        TableGenTypes.COMMA -> arrayOf(DefaultLanguageHighlighterColors.COMMA)
-        TableGenTypes.SEMICOLON -> arrayOf(DefaultLanguageHighlighterColors.SEMICOLON)
-        TableGenTypes.DOT -> arrayOf(DefaultLanguageHighlighterColors.DOT)
-        StringEscapesTokenTypes.VALID_STRING_ESCAPE_TOKEN -> arrayOf(DefaultLanguageHighlighterColors.VALID_STRING_ESCAPE)
+        TableGenTypes.INTEGER -> arrayOf(NUMBER)
+        TableGenTypes.BLOCK_COMMENT -> arrayOf(BLOCK_COMMENT)
+        TableGenTypes.LINE_COMMENT -> arrayOf(LINE_COMMENT)
+        TableGenTypes.LBRACE, TableGenTypes.RBRACE -> arrayOf(BRACES)
+        TableGenTypes.LPAREN, TableGenTypes.RPAREN -> arrayOf(PARENTHESES)
+        TableGenTypes.LBRACKET, TableGenTypes.RBRACKET -> arrayOf(BRACKETS)
+        TableGenTypes.IDENTIFIER -> arrayOf(IDENTIFIER)
+        TableGenTypes.COMMA -> arrayOf(COMMA)
+        TableGenTypes.SEMICOLON -> arrayOf(SEMICOLON)
+        TableGenTypes.DOT -> arrayOf(DOT)
+        StringEscapesTokenTypes.VALID_STRING_ESCAPE_TOKEN -> arrayOf(STRING_ESCAPE)
         else -> when {
-            KEYWORDS.contains(tokenType) -> arrayOf(DefaultLanguageHighlighterColors.KEYWORD)
-            PUNCTUATION.contains(tokenType) -> arrayOf(DefaultLanguageHighlighterColors.OPERATION_SIGN)
-            STRING_LITERALS.contains(tokenType) -> arrayOf(DefaultLanguageHighlighterColors.STRING)
+            KEYWORDS.contains(tokenType) -> arrayOf(KEYWORD)
+            PUNCTUATION.contains(tokenType) -> arrayOf(OPERATION_SIGN)
+            STRING_LITERALS.contains(tokenType) -> arrayOf(STRING)
             else -> emptyArray()
         }
     }

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/highlighting/TableGenSemanticTokensAnnotator.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/highlighting/TableGenSemanticTokensAnnotator.kt
@@ -1,10 +1,10 @@
 package com.github.zero9178.mlirods.language.highlighting
 
+import com.github.zero9178.mlirods.color.FIELD
 import com.github.zero9178.mlirods.language.generated.psi.TableGenLetDirective
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
 import com.intellij.lang.annotation.HighlightSeverity
-import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
 import com.intellij.openapi.project.DumbAware
 import com.intellij.psi.PsiElement
 
@@ -14,7 +14,7 @@ private class TableGenSemanticTokensAnnotator : Annotator, DumbAware {
             is TableGenLetDirective -> {
                 holder.newSilentAnnotation(HighlightSeverity.TEXT_ATTRIBUTES)
                     .range(element.identifier)
-                    .textAttributes(DefaultLanguageHighlighterColors.INSTANCE_FIELD)
+                    .textAttributes(FIELD)
                     .create()
             }
         }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -28,6 +28,7 @@
                            implementationClass="com.github.zero9178.mlirods.language.TableGenQuoteHandler"/>
         <annotator language="TableGen"
                    implementationClass="com.github.zero9178.mlirods.language.highlighting.TableGenSemanticTokensAnnotator"/>
+        <colorSettingsPage implementation="com.github.zero9178.mlirods.color.TableGenColorSettingsPage"/>
     </extensions>
 
     <extensions defaultExtensionNs="com.intellij.platform.lsp">

--- a/src/test/kotlin/com/github/zero9178/mlirods/SemanticTokensAnnotatorTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/SemanticTokensAnnotatorTest.kt
@@ -11,7 +11,7 @@ class SemanticTokensAnnotatorTest : BasePlatformTestCase() {
                 string s = ?;
             }
             def Foo : Foo {
-                let <text_attr textAttributesKey="DEFAULT_INSTANCE_FIELD">s</text_attr> = "";
+                let <text_attr textAttributesKey="TABLEGEN_FIELD">s</text_attr> = "";
             }
         """.trimIndent()
         )


### PR DESCRIPTION
The syntax highlighting up until now used the fallback colours from the IDE up until now. This makes it impossible to configure the colours the IDE should use for TableGen syntax highlighting without also affecting other languages. This PR therefore adds a colour page with new text attribute keys that have descriptive names for elements found in TableGen.