### PR TITLE
[ci] Don't cache verifier

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,6 +211,9 @@ jobs:
       # Setup Gradle
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+            # Caching the IDE downloads is too expensive.
+            cache-read-only: true
 
       # Cache Plugin Verifier IDEs
       - name: Setup Plugin Verifier IDEs Cache


### PR DESCRIPTION
Verification requires downloading the entire IDE which with larger IDE matrices are incredibly large to the point where it crashes the GitHub action runners. Rather download them each time as that seems to be much sparser for some reason.