### PR TITLE
[Completion] Fix missing completions in dumb mode

### DIFF
--- a/src/test/kotlin/com/github/zero9178/mlirods/CompletionTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/CompletionTest.kt
@@ -1,5 +1,6 @@
 package com.github.zero9178.mlirods
 
+import com.intellij.testFramework.DumbModeTestUtils
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 
 class CompletionTest : BasePlatformTestCase() {
@@ -25,5 +26,22 @@ class CompletionTest : BasePlatformTestCase() {
         myFixture.completeBasic()
         val list = requireNotNull(myFixture.lookupElementStrings)
         assertSameElements(list, "values")
+    }
+
+    fun `test dumb field lookup`() {
+        myFixture.configureByText(
+            "test.td", """
+            defvar v = 0;
+            
+            class A : B {
+                int i = <caret>;
+            }
+        """.trimIndent()
+        )
+
+        DumbModeTestUtils.computeInDumbModeSynchronously(project) {
+            myFixture.completeBasic()
+            assertSameElements(requireNotNull(myFixture.lookupElementStrings), "v")
+        }
     }
 }


### PR DESCRIPTION
Field lookup may perform index lookup which throws an exception in dumb mode and therefore does not use any so far collected elements.

This PR fixes this by not performing field lookup. Field lookup will be readded later with a dedicated field reference contributor