### PR TITLE
[LSP] Disable all but diagnostic

### DIFF
--- a/src/main/kotlin/com/github/zero9178/mlirods/lsp/TableGenLspServerDescriptor.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/lsp/TableGenLspServerDescriptor.kt
@@ -12,7 +12,10 @@ import com.intellij.platform.lsp.api.LspServerListener
 import com.intellij.platform.lsp.api.LspServerManager
 import com.intellij.platform.lsp.api.ProjectWideLspServerDescriptor
 import com.intellij.platform.lsp.api.customization.LspCodeActionsSupport
+import com.intellij.platform.lsp.api.customization.LspCompletionSupport
 import com.intellij.platform.lsp.api.customization.LspDocumentLinkSupport
+import com.intellij.platform.lsp.api.customization.LspFindReferencesSupport
+import com.intellij.platform.lsp.api.customization.LspSemanticTokensSupport
 import com.intellij.util.io.BaseDataReader
 import com.intellij.util.io.BaseOutputReader
 import java.io.File
@@ -117,6 +120,21 @@ class TableGenLspServerDescriptor(
         get() = null
 
     override val lspDocumentLinkSupport: LspDocumentLinkSupport?
+        get() = null
+
+    override val lspCompletionSupport: LspCompletionSupport?
+        get() = null
+
+    override val lspFindReferencesSupport: LspFindReferencesSupport?
+        get() = null
+
+    override val lspGoToDefinitionSupport: Boolean
+        get() = false
+
+    override val lspGoToTypeDefinitionSupport: Boolean
+        get() = false
+
+    override val lspSemanticTokensSupport: LspSemanticTokensSupport?
         get() = null
 }
 


### PR DESCRIPTION
At this point the IDE is more capable at performing the majority of these tasks. Some of these, such as find usages, show up as an additional menu, making it confusing to users which functionality is provided by the LSP or by the IDE.

Disable all but diagnostics support in the LSP for now. Diagnostics is likely to be the last thing that will be replaced if ever