### PR TITLE
[highlighting] Use `HighlightVisitor` rather than `Annotator` for syn…

### DIFF
--- a/src/main/kotlin/com/github/zero9178/mlirods/language/highlighting/TableGenSemanticTokensAnnotator.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/highlighting/TableGenSemanticTokensAnnotator.kt
@@ -3,63 +3,131 @@ package com.github.zero9178.mlirods.language.highlighting
 import com.github.zero9178.mlirods.color.FIELD
 import com.github.zero9178.mlirods.color.PREPROCESSOR_MACRO_NAME
 import com.github.zero9178.mlirods.color.SKIPPED_CODE
+import com.github.zero9178.mlirods.language.TableGenFile
 import com.github.zero9178.mlirods.language.generated.psi.*
 import com.github.zero9178.mlirods.language.psi.TableGenFieldIdentifierNode
-import com.intellij.lang.annotation.AnnotationHolder
-import com.intellij.lang.annotation.Annotator
-import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.codeInsight.daemon.RainbowVisitor
+import com.intellij.codeInsight.daemon.impl.HighlightInfo
+import com.intellij.codeInsight.daemon.impl.HighlightInfoType
+import com.intellij.codeInsight.daemon.impl.HighlightVisitor
+import com.intellij.codeInsight.daemon.impl.analysis.HighlightInfoHolder
 import com.intellij.openapi.project.DumbAware
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 
-private class TableGenDumbAwareSemanticTokensAnnotator : Annotator, DumbAware {
-    override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+private class TableGenDumbAwareSemanticTokensAnnotator : HighlightVisitor, DumbAware {
+
+    private var myHolder: HighlightInfoHolder? = null
+
+
+    private fun addInfo(highlightInfo: HighlightInfo?) {
+        myHolder!!.add(highlightInfo)
+    }
+
+    override fun clone(): HighlightVisitor {
+        return TableGenDumbAwareSemanticTokensAnnotator()
+    }
+
+    override fun suitableForFile(file: PsiFile): Boolean {
+        return file is TableGenFile
+    }
+
+    override fun analyze(
+        file: PsiFile,
+        updateWholeFile: Boolean,
+        holder: HighlightInfoHolder,
+        action: Runnable
+    ): Boolean {
+        myHolder = holder
+        action.run()
+        return true
+    }
+
+    override fun visit(element: PsiElement) {
         when (element) {
             is TableGenFieldIdentifierNode -> {
                 element.fieldIdentifier?.let {
-                    holder.newSilentAnnotation(HighlightSeverity.TEXT_ATTRIBUTES)
-                        .range(it)
-                        .textAttributes(FIELD)
-                        .create()
+                    addInfo(
+                        HighlightInfo.newHighlightInfo(HighlightInfoType.TEXT_ATTRIBUTES)
+                            .range(it)
+                            .textAttributes(FIELD)
+                            .create()
+                    )
                 }
             }
 
             is TableGenDefineDirective -> {
                 val identifier = element.identifier ?: return
-                holder.newSilentAnnotation(HighlightSeverity.TEXT_ATTRIBUTES)
-                    .range(identifier)
-                    .textAttributes(PREPROCESSOR_MACRO_NAME)
-                    .create()
+                addInfo(
+                    HighlightInfo.newHighlightInfo(HighlightInfoType.TEXT_ATTRIBUTES)
+                        .range(identifier)
+                        .textAttributes(PREPROCESSOR_MACRO_NAME)
+                        .create()
+                )
             }
 
             is TableGenIfdefIfndefDirective -> {
                 val identifier = element.identifier ?: return
-                holder.newSilentAnnotation(HighlightSeverity.TEXT_ATTRIBUTES)
-                    .range(identifier)
-                    .textAttributes(PREPROCESSOR_MACRO_NAME)
-                    .create()
+                addInfo(
+                    HighlightInfo.newHighlightInfo(HighlightInfoType.TEXT_ATTRIBUTES)
+                        .range(identifier)
+                        .textAttributes(PREPROCESSOR_MACRO_NAME)
+                        .create()
+                )
             }
 
             is TableGenSkippedCodeBlock -> {
-                holder.newSilentAnnotation(HighlightSeverity.TEXT_ATTRIBUTES)
-                    .range(element)
-                    .textAttributes(SKIPPED_CODE)
-                    .create()
+                addInfo(
+                    HighlightInfo.newHighlightInfo(HighlightInfoType.TEXT_ATTRIBUTES)
+                        .range(element)
+                        .textAttributes(SKIPPED_CODE)
+                        .create()
+                )
             }
         }
     }
 }
 
-private class TableGenSemanticTokensAnnotator : Annotator {
-    override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+private class TableGenSemanticTokensAnnotator : HighlightVisitor {
+
+    private var myHolder: HighlightInfoHolder? = null
+
+
+    private fun addInfo(highlightInfo: HighlightInfo?) {
+        myHolder!!.add(highlightInfo)
+    }
+
+    override fun clone(): HighlightVisitor {
+        return TableGenSemanticTokensAnnotator()
+    }
+
+    override fun suitableForFile(file: PsiFile): Boolean {
+        return file is TableGenFile
+    }
+
+    override fun analyze(
+        file: PsiFile,
+        updateWholeFile: Boolean,
+        holder: HighlightInfoHolder,
+        action: Runnable
+    ): Boolean {
+        myHolder = holder
+        action.run()
+        return true
+    }
+
+    override fun visit(element: PsiElement) {
         when (element) {
             is TableGenIdentifierValue -> {
                 if (element.reference?.resolve() !is TableGenFieldBodyItem)
                     return
 
-                holder.newSilentAnnotation(HighlightSeverity.TEXT_ATTRIBUTES)
-                    .range(element)
-                    .textAttributes(FIELD)
-                    .create()
+                addInfo(
+                    HighlightInfo.newHighlightInfo(HighlightInfoType.TEXT_ATTRIBUTES)
+                        .range(element)
+                        .textAttributes(FIELD)
+                        .create()
+                )
             }
         }
     }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -28,10 +28,10 @@
                         implementationClass="com.github.zero9178.mlirods.language.TableGenCommenter"/>
         <lang.quoteHandler language="TableGen"
                            implementationClass="com.github.zero9178.mlirods.language.TableGenQuoteHandler"/>
-        <annotator language="TableGen"
-                   implementationClass="com.github.zero9178.mlirods.language.highlighting.TableGenSemanticTokensAnnotator"/>
-        <annotator language="TableGen"
-                   implementationClass="com.github.zero9178.mlirods.language.highlighting.TableGenDumbAwareSemanticTokensAnnotator"/>
+        <highlightVisitor
+                implementation="com.github.zero9178.mlirods.language.highlighting.TableGenSemanticTokensAnnotator"/>
+        <highlightVisitor
+                implementation="com.github.zero9178.mlirods.language.highlighting.TableGenDumbAwareSemanticTokensAnnotator"/>
         <colorSettingsPage implementation="com.github.zero9178.mlirods.color.TableGenColorSettingsPage"/>
         <lang.foldingBuilder language="TableGen"
                              implementationClass="com.github.zero9178.mlirods.language.TableGenFoldingBuilder"/>


### PR DESCRIPTION
…tax highlighting

The latter shows up in code inspection when it is only meant to be used for semantic syntax highlighting. I sadly do not yet know how to test this.