### PR TITLE
[gradle] Increase CLion memory

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -239,6 +239,11 @@ intellijPlatformTesting {
             type = IntelliJPlatformType.CLion
             version = providers.gradleProperty("platformVersion")
             sandboxDirectory = intellijPlatform.sandboxContainer.dir("runCL-sandbox")
+            task {
+                jvmArgumentProviders += CommandLineArgumentProvider {
+                    listOf("-Xmx8192m")
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
LLVM is just so huge no way the default 2GB Heap space is enough