### PR TITLE
[Stubs] Implement stubs for `template arg decl`

### DIFF
--- a/src/main/kotlin/com/github/zero9178/mlirods/language/TableGen.bnf
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/TableGen.bnf
@@ -241,10 +241,12 @@ template_arg_decl ::= type_node IDENTIFIER equals_value? {
     methods=[
         nameIdentifier='IDENTIFIER'
 
-        getName
         setName
         getTextOffset
     ]
+    stubClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenTemplateArgDeclStub"
+    mixin="com.github.zero9178.mlirods.language.psi.impl.TableGenTemplateArgDeclMixin"
+    elementTypeClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenTemplateArgDeclStubElementType"
 }
 private record_body ::= <<parent_class_list class_ref>>? body {pin=1}
 private meta parent_class_list ::= ':' <<class_ref>> (',' <<class_ref>>)* {pin(".*")=1}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenTemplateArgDeclMixin.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenTemplateArgDeclMixin.kt
@@ -1,0 +1,22 @@
+package com.github.zero9178.mlirods.language.psi.impl
+
+import com.github.zero9178.mlirods.language.generated.psi.TableGenTemplateArgDecl
+import com.github.zero9178.mlirods.language.stubs.impl.TableGenTemplateArgDeclStub
+import com.intellij.extapi.psi.StubBasedPsiElementBase
+import com.intellij.lang.ASTNode
+import com.intellij.psi.stubs.IStubElementType
+
+abstract class TableGenTemplateArgDeclMixin : StubBasedPsiElementBase<TableGenTemplateArgDeclStub>,
+    TableGenTemplateArgDecl {
+
+    constructor(node: ASTNode) : super(node)
+
+    constructor(stub: TableGenTemplateArgDeclStub, stubType: IStubElementType<*, *>) : super(stub, stubType)
+
+    override fun getName(): String? {
+        stub?.let {
+            return it.name
+        }
+        return nameIdentifier?.text
+    }
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/TableGenStubElementTypes.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/TableGenStubElementTypes.kt
@@ -17,6 +17,9 @@ interface TableGenStubElementTypes {
         val DEF_STATEMENT = TableGenTypes.DEF_STATEMENT!!
 
         @JvmField
+        val TEMPLATE_ARG_DECL = TableGenTypes.TEMPLATE_ARG_DECL!!
+
+        @JvmField
         val CLASS_STATEMENT = TableGenTypes.CLASS_STATEMENT!!
 
         @JvmField

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/TableGenStubFileElementType.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/TableGenStubFileElementType.kt
@@ -25,7 +25,7 @@ class TableGenStubFileElementType :
     }
 
     override fun getStubVersion(): Int {
-        return 5
+        return 6
     }
 
     companion object {

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/impl/TableGenTemplateArgDeclStub.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/impl/TableGenTemplateArgDeclStub.kt
@@ -1,0 +1,56 @@
+package com.github.zero9178.mlirods.language.stubs.impl
+
+import com.github.zero9178.mlirods.language.generated.psi.TableGenTemplateArgDecl
+import com.github.zero9178.mlirods.language.generated.psi.impl.TableGenTemplateArgDeclImpl
+import com.github.zero9178.mlirods.language.stubs.TableGenStubElementType
+import com.github.zero9178.mlirods.language.stubs.TableGenStubElementTypes
+import com.intellij.psi.PsiElement
+import com.intellij.psi.stubs.StubBase
+import com.intellij.psi.stubs.StubElement
+import com.intellij.psi.stubs.StubInputStream
+import com.intellij.psi.stubs.StubOutputStream
+
+/**
+ * Stub interface for [TableGenTemplateArgDecl].
+ */
+interface TableGenTemplateArgDeclStub : StubElement<TableGenTemplateArgDecl> {
+    val name: String?
+    val hasDefault: Boolean
+}
+
+class TableGenTemplateArgDeclStubElementType(debugName: String) :
+    TableGenStubElementType<TableGenTemplateArgDeclStub, TableGenTemplateArgDecl>(
+        debugName, ::TableGenTemplateArgDeclImpl
+    ) {
+
+    override fun createStub(
+        psi: TableGenTemplateArgDecl, parentStub: StubElement<out PsiElement?>?
+    ): TableGenTemplateArgDeclStub {
+        return TableGenTemplateArgDeclStubImpl(psi.name, psi.value != null, parentStub)
+    }
+
+    override fun serialize(
+        stub: TableGenTemplateArgDeclStub, dataStream: StubOutputStream
+    ) {
+        dataStream.writeBoolean(stub.name != null)
+        stub.name?.let { dataStream.writeUTFFast(it) }
+        dataStream.writeBoolean(stub.hasDefault)
+    }
+
+    override fun deserialize(
+        dataStream: StubInputStream, parentStub: StubElement<*>?
+    ): TableGenTemplateArgDeclStub {
+        val hasName = dataStream.readBoolean()
+        val name = if (hasName) {
+            dataStream.readUTFFast()
+        } else null
+        val hasDefault = dataStream.readBoolean()
+        return TableGenTemplateArgDeclStubImpl(name, hasDefault, parentStub)
+    }
+}
+
+private class TableGenTemplateArgDeclStubImpl(
+    override val name: String?, override val hasDefault: Boolean, parent: StubElement<out PsiElement>?
+) : StubBase<TableGenTemplateArgDecl>(
+    parent, TableGenStubElementTypes.TEMPLATE_ARG_DECL
+), TableGenTemplateArgDeclStub


### PR DESCRIPTION
This is useful for the insert handler to not need to load an AST to know whether a class statement has arguments. In the future it will also be useful for parameter info