### PR TITLE
[TableGen] Implement brace insertion for block string literals

### DIFF
--- a/src/main/kotlin/com/github/zero9178/mlirods/language/TableGenTypedHandlerDelegate.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/TableGenTypedHandlerDelegate.kt
@@ -1,0 +1,38 @@
+package com.github.zero9178.mlirods.language
+
+import com.intellij.codeInsight.editorActions.TypedHandlerDelegate
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiFile
+
+private class TableGenTypedHandlerDelegate : TypedHandlerDelegate() {
+    override fun charTyped(
+        c: Char,
+        project: Project,
+        editor: Editor,
+        file: PsiFile
+    ): Result {
+        if (file.fileType != TableGenFileType.INSTANCE)
+            return Result.CONTINUE
+
+        if (c != '{')
+            return Result.CONTINUE
+
+        val offset = editor.caretModel.offset
+        if (offset < 2)
+            return Result.CONTINUE
+
+        val doc = editor.document
+        if (offset + 1 > doc.textLength)
+            return Result.CONTINUE
+
+        if (editor.document.charsSequence.subSequence(offset - 2, offset + 1) != "[{]")
+            return Result.CONTINUE
+
+        PsiDocumentManager.getInstance(project).commitDocument(doc)
+        doc.insertString(offset, "}")
+
+        return Result.CONTINUE
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -28,6 +28,7 @@
                         implementationClass="com.github.zero9178.mlirods.language.TableGenCommenter"/>
         <lang.quoteHandler language="TableGen"
                            implementationClass="com.github.zero9178.mlirods.language.TableGenQuoteHandler"/>
+        <typedHandler implementation="com.github.zero9178.mlirods.language.TableGenTypedHandlerDelegate"/>
         <highlightVisitor
                 implementation="com.github.zero9178.mlirods.language.highlighting.TableGenSemanticTokensAnnotator"/>
         <highlightVisitor

--- a/src/test/kotlin/com/github/zero9178/mlirods/EditorTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/EditorTest.kt
@@ -2,6 +2,7 @@ package com.github.zero9178.mlirods
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 
+
 class EditorTest : BasePlatformTestCase() {
 
     fun `test brace matching`() {
@@ -20,5 +21,17 @@ class EditorTest : BasePlatformTestCase() {
             """.trimIndent()
             )
         }
+        myFixture.configureByText(
+            "test.td", """
+                [<caret>]
+            """.trimIndent()
+        )
+
+        myFixture.type('{')
+        myFixture.checkResult(
+            """
+                [{<caret>}]
+            """.trimIndent()
+        )
     }
 }


### PR DESCRIPTION
Fixes https://github.com/zero9178/IntelliJ-MLIR-ODS/issues/170