### PR TITLE
[TableGen] Enable stub access generation for type nodes

### DIFF
--- a/src/main/kotlin/com/github/zero9178/mlirods/language/TableGen.bnf
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/TableGen.bnf
@@ -474,41 +474,37 @@ type_node ::= bit_type_node
     methods=[
         toString
     ]
+    stubClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenTypeNodeStub"
     mixin="com.github.zero9178.mlirods.language.psi.impl.TableGenTypeNodeMixin"
 }
 bit_type_node ::= 'bit' {
     methods=[
         toType
     ]
-    stubClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenTypeNodeStub"
     elementTypeClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenBitTypeNodeStubElementType"
 }
 int_type_node ::= 'int' {
     methods=[
         toType
     ]
-    stubClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenTypeNodeStub"
     elementTypeClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenIntTypeNodeStubElementType"
 }
 string_type_node ::= 'string' {
     methods=[
         toType
     ]
-    stubClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenTypeNodeStub"
     elementTypeClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenStringTypeNodeStubElementType"
 }
 dag_type_node ::= 'dag' {
     methods=[
         toType
     ]
-    stubClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenTypeNodeStub"
     elementTypeClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenDagTypeNodeStubElementType"
 }
 code_type_node ::= 'code' {
     methods=[
         toType
     ]
-    stubClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenTypeNodeStub"
     elementTypeClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenCodeTypeNodeStubElementType"
 }
 bits_type_node ::= 'bits' '<' INTEGER '>' {
@@ -516,7 +512,6 @@ bits_type_node ::= 'bits' '<' INTEGER '>' {
     methods=[
         toType
     ]
-    stubClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenTypeNodeStub"
     elementTypeClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenBitsTypeNodeStubElementType"
 }
 list_type_node ::= 'list' '<' type_node '>' {
@@ -524,7 +519,6 @@ list_type_node ::= 'list' '<' type_node '>' {
     methods=[
         toType
     ]
-    stubClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenTypeNodeStub"
     elementTypeClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenListTypeNodeStubElementType"
 }
 class_type_node ::= IDENTIFIER {
@@ -536,8 +530,11 @@ class_type_node ::= IDENTIFIER {
         toString
         toType
     ]
-    implements=abstract_class_ref
-    stubClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenClassTypeNodeStub"
+    implements=[
+        abstract_class_ref
+
+        "com.github.zero9178.mlirods.language.psi.impl.TableGenClassTypeNodeEx"
+    ]
     mixin="com.github.zero9178.mlirods.language.psi.impl.TableGenClassTypeNodeMixin"
     elementTypeClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenClassTypeNodeStubElementType"
 }

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenClassTypeNodeEx.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenClassTypeNodeEx.kt
@@ -1,0 +1,9 @@
+package com.github.zero9178.mlirods.language.psi.impl
+
+import com.github.zero9178.mlirods.language.stubs.impl.TableGenClassTypeNodeStub
+import com.github.zero9178.mlirods.language.stubs.impl.TableGenTypeNodeStub
+import com.intellij.psi.StubBasedPsiElement
+
+interface TableGenClassTypeNodeEx : StubBasedPsiElement<TableGenTypeNodeStub> {
+    override fun getStub(): TableGenClassTypeNodeStub?
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenClassTypeNodeMixin.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenClassTypeNodeMixin.kt
@@ -3,6 +3,7 @@ package com.github.zero9178.mlirods.language.psi.impl
 import com.github.zero9178.mlirods.language.generated.psi.TableGenArgValueItem
 import com.github.zero9178.mlirods.language.generated.psi.TableGenClassTypeNode
 import com.github.zero9178.mlirods.language.stubs.impl.TableGenClassTypeNodeStub
+import com.github.zero9178.mlirods.language.stubs.impl.TableGenTypeNodeStub
 import com.intellij.extapi.psi.StubBasedPsiElementBase
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
@@ -13,7 +14,12 @@ abstract class TableGenClassTypeNodeMixin : StubBasedPsiElementBase<TableGenClas
 
     constructor(node: ASTNode) : super(node)
 
-    constructor(stub: TableGenClassTypeNodeStub, stubType: IStubElementType<*, *>) : super(stub, stubType)
+    // NOTE: This has to be 'TableGenTypeNodeStub' due to the two phase compilation with grammar kit. More precisely,
+    // the stub type here has to match the 'StubBasedPsiElement' interface exactly.
+    constructor(stub: TableGenTypeNodeStub, stubType: IStubElementType<*, *>) : super(
+        stub as TableGenClassTypeNodeStub,
+        stubType
+    )
 
     override fun getArgValueItemList(): List<TableGenArgValueItem> = emptyList()
 


### PR DESCRIPTION
Despite all type node alternatives being stubs, users of `type_node` were still generating getters performing AST access. This PR works around the issue while retaining strong typing of stubs by using covariant return types.