### PR TITLE
[TableGen] Amortized identifier lookup with stub support

### DIFF
--- a/src/main/kotlin/com/github/zero9178/mlirods/language/TableGen.bnf
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/TableGen.bnf
@@ -732,7 +732,11 @@ foreach_operator_value_node ::= '!foreach' '(' bang_operator_definition ',' valu
         body="/value_node[1]"
         iterator="/bang_operator_definition"
 
+        getDirectIdMap
         getType
+    ]
+    implements=[
+        "com.github.zero9178.mlirods.language.psi.TableGenIdentifierScopeNode"
     ]
 }
 
@@ -745,7 +749,11 @@ foldl_operator_value_node ::= '!foldl' '(' value_node ',' value_node ',' bang_op
         accmulator="/bang_operator_definition[0]"
         iterator="/bang_operator_definition[1]"
 
+        getDirectIdMap
         getType
+    ]
+    implements=[
+        "com.github.zero9178.mlirods.language.psi.TableGenIdentifierScopeNode"
     ]
 }
 

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenFile.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenFile.kt
@@ -2,6 +2,7 @@ package com.github.zero9178.mlirods.language.psi
 
 import com.github.zero9178.mlirods.language.TableGenFileType
 import com.github.zero9178.mlirods.language.TableGenLanguage
+import com.github.zero9178.mlirods.language.generated.TableGenTypes
 import com.github.zero9178.mlirods.language.generated.psi.TableGenClassStatement
 import com.github.zero9178.mlirods.language.generated.psi.TableGenIncludeDirective
 import com.github.zero9178.mlirods.language.stubs.TableGenStubElementTypes
@@ -10,6 +11,8 @@ import com.intellij.extapi.psi.PsiFileBase
 import com.intellij.openapi.fileTypes.FileType
 import com.intellij.psi.FileViewProvider
 import com.intellij.psi.stubs.IStubElementType
+import com.intellij.psi.tree.TokenSet
+import com.intellij.util.ArrayFactory
 import com.intellij.util.resettableLazy
 
 class TableGenFile(viewProvider: FileViewProvider, val context: TableGenContext) :
@@ -55,8 +58,29 @@ class TableGenFile(viewProvider: FileViewProvider, val context: TableGenContext)
     val classMap: Map<String, List<TableGenClassStatement>> by myClassMap
 
 
+    private var myDirectIdMap = resettableLazy {
+        withGreenStubOrAst<(TokenSet, ArrayFactory<TableGenIdentifierElement>) -> Array<TableGenIdentifierElement>>({
+            it::getChildrenByType
+        }) {
+            it::getChildrenAsPsiElements
+        }(TokenSet.create(TableGenTypes.DEF_STATEMENT, TableGenTypes.DEFVAR_STATEMENT)) {
+            arrayOfNulls<TableGenIdentifierElement>(it)
+        }
+            .mapNotNull {
+                val name = it.name ?: return@mapNotNull null
+                name to it
+            }.groupBy({
+                it.first
+            }) {
+                TableGenIdentifierScopeNode.IdMapEntry(it.second)
+            }
+    }
+
+    override val directIdMap by myDirectIdMap
+
     override fun subtreeChanged() {
         super.subtreeChanged()
         myClassMap.reset()
+        myDirectIdMap.reset()
     }
 }

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenIdentifierScopeNode.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenIdentifierScopeNode.kt
@@ -1,8 +1,72 @@
 package com.github.zero9178.mlirods.language.psi
 
 import com.intellij.psi.PsiElement
+import com.intellij.psi.util.CachedValuesManager
+import com.intellij.psi.util.childrenOfType
+import com.intellij.psi.util.parentOfType
 
 /**
- * Interface implemented by any [PsiElement] which creates a scope of elements found by 'def' lookup.
+ * Interface implemented by any [PsiElement] which creates a scope of elements found by 'identifier' lookup.
  */
-interface TableGenIdentifierScopeNode : PsiElement
+interface TableGenIdentifierScopeNode : PsiElement {
+
+    /**
+     * Entry within an id map. An entry consists of two elements: The one to be found by the lookup, and its occurrence
+     * within the source file. These are usually the same except for elements that may be found through inheritance
+     * (e.g. fields), where the reference that imports them is the occurrence.
+     */
+    data class IdMapEntry(val element: TableGenIdentifierElement, val occurrence: PsiElement) {
+
+        constructor(element: TableGenIdentifierElement) : this(element, element)
+
+        /**
+         * Compares the lexicographical position of [occurrence] with [element].
+         */
+        operator fun compareTo(element: PsiElement): Int = requireNotNull(occurrence.compareTo(element)) {
+            "occurrences should have been in the same file"
+        }
+
+        /**
+         * Compares the lexicographical position of the [occurrence]s.
+         */
+        operator fun compareTo(element: IdMapEntry) = compareTo(element.occurrence)
+    }
+
+    /**
+     * Returns a map containing all elements that can be found by def lookup directly nested within this scope.
+     * Elements with the same name are within a list ordered by lexical appearance of the occurrence element.
+     * Every occurrence must therefore be in the same file as 'this' and must start after 'this'.
+     */
+    val directIdMap: Map<String, List<IdMapEntry>>
+        get() = CachedValuesManager.getProjectPsiDependentCache(this) { element ->
+            element.childrenOfType<TableGenIdentifierElement>().mapNotNull {
+                val name = it.name ?: return@mapNotNull null
+                name to it
+            }.groupBy({
+                it.first
+            }) {
+                IdMapEntry(it.second)
+            }
+        }
+
+    /**
+     * Same as [directIdMap], but contains elements from every parent scope as well.
+     * Lexicographical sorting of elements in lists is preserved.
+     */
+    val idMap: Map<String, List<IdMapEntry>>
+        get() = CachedValuesManager.getProjectPsiDependentCache(this) {
+            val parentMap = parentOfType<TableGenIdentifierScopeNode>(withSelf = false)?.idMap
+                ?: return@getProjectPsiDependentCache directIdMap
+
+            val result = directIdMap.toMutableMap()
+            parentMap.entries.forEach { (k, v) ->
+                // Drop all elements from the parent that occur before 'this'.
+                result.merge(k, v.takeWhile {
+                    it < this
+                }) { directList, parentList ->
+                    parentList + directList
+                }
+            }
+            result
+        }
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/Util.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/Util.kt
@@ -1,0 +1,26 @@
+package com.github.zero9178.mlirods.language.psi
+
+import com.intellij.extapi.psi.StubBasedPsiElementBase
+import com.intellij.psi.PsiElement
+import com.intellij.psi.stubs.StubBase
+import com.intellij.psi.util.startOffset
+
+/**
+ * Performs a lexicographical comparison of 'this' with 'other'.
+ * Returns null if the elements are in different files.
+ */
+fun PsiElement.compareTo(other: PsiElement): Int? {
+    if (this is StubBasedPsiElementBase<*> && other is StubBasedPsiElementBase<*>) {
+        val stub = this.stub as? StubBase
+        if (stub != null) {
+            val otherStub = other.stub as? StubBase ?: return null
+            if (stub.containingFileStub != otherStub.containingFileStub)
+                return null
+            return stub.compareByOrderWith(otherStub)
+        }
+    }
+    if (containingFile != other.containingFile)
+        return null
+
+    return startOffset.compareTo(other.startOffset)
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenDefStatementMixin.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenDefStatementMixin.kt
@@ -6,6 +6,7 @@ import com.github.zero9178.mlirods.language.stubs.impl.TableGenIdentifierElement
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
+import com.intellij.util.resettableLazy
 
 abstract class TableGenDefStatementMixin : TableGenRecordStatementMixin<TableGenIdentifierElementStub>,
     TableGenDefStatement, PsiElement {
@@ -16,5 +17,23 @@ abstract class TableGenDefStatementMixin : TableGenRecordStatementMixin<TableGen
 
     override fun getNameIdentifier(): PsiElement? {
         return valueNode as? TableGenIdentifierValueNode
+    }
+
+    private var myDirectIdMap = resettableLazy {
+        bodyIdEntries.mapNotNull {
+            val name = it.element.name ?: return@mapNotNull null
+            name to it
+        }.groupBy({
+            it.first
+        }) {
+            it.second
+        }
+    }
+
+    override val directIdMap by myDirectIdMap
+
+    override fun subtreeChanged() {
+        super.subtreeChanged()
+        myDirectIdMap.reset()
     }
 }

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenForeachStatementMixin.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenForeachStatementMixin.kt
@@ -1,10 +1,14 @@
 package com.github.zero9178.mlirods.language.psi.impl
 
 import com.github.zero9178.mlirods.language.generated.psi.TableGenForeachStatement
+import com.github.zero9178.mlirods.language.psi.TableGenIdentifierElement
+import com.github.zero9178.mlirods.language.psi.TableGenIdentifierScopeNode
 import com.github.zero9178.mlirods.language.stubs.impl.TableGenStatementStub
+import com.github.zero9178.mlirods.language.stubs.stubbedChildren
 import com.intellij.extapi.psi.StubBasedPsiElementBase
 import com.intellij.lang.ASTNode
 import com.intellij.psi.stubs.IStubElementType
+import com.intellij.util.resettableLazy
 
 abstract class TableGenForeachStatementMixin : StubBasedPsiElementBase<TableGenStatementStub>,
     TableGenForeachStatement {
@@ -12,4 +16,22 @@ abstract class TableGenForeachStatementMixin : StubBasedPsiElementBase<TableGenS
     constructor(node: ASTNode) : super(node)
 
     constructor(stub: TableGenStatementStub, stubType: IStubElementType<*, *>) : super(stub, stubType)
+
+    private var myDirectIdMap = resettableLazy {
+        stubbedChildren<TableGenIdentifierElement>().mapNotNull {
+            val name = it.name ?: return@mapNotNull null
+            name to it
+        }.groupBy({
+            it.first
+        }) {
+            TableGenIdentifierScopeNode.IdMapEntry(it.second)
+        }
+    }
+
+    override val directIdMap by myDirectIdMap
+
+    override fun subtreeChanged() {
+        super.subtreeChanged()
+        myDirectIdMap.reset()
+    }
 }

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenLetStatementMixin.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenLetStatementMixin.kt
@@ -1,10 +1,14 @@
 package com.github.zero9178.mlirods.language.psi.impl
 
 import com.github.zero9178.mlirods.language.generated.psi.TableGenLetStatement
+import com.github.zero9178.mlirods.language.psi.TableGenIdentifierElement
+import com.github.zero9178.mlirods.language.psi.TableGenIdentifierScopeNode
 import com.github.zero9178.mlirods.language.stubs.impl.TableGenStatementStub
+import com.github.zero9178.mlirods.language.stubs.stubbedChildren
 import com.intellij.extapi.psi.StubBasedPsiElementBase
 import com.intellij.lang.ASTNode
 import com.intellij.psi.stubs.IStubElementType
+import com.intellij.util.resettableLazy
 
 abstract class TableGenLetStatementMixin : StubBasedPsiElementBase<TableGenStatementStub>,
     TableGenLetStatement {
@@ -12,4 +16,22 @@ abstract class TableGenLetStatementMixin : StubBasedPsiElementBase<TableGenState
     constructor(node: ASTNode) : super(node)
 
     constructor(stub: TableGenStatementStub, stubType: IStubElementType<*, *>) : super(stub, stubType)
+
+    private var myDirectIdMap = resettableLazy {
+        stubbedChildren<TableGenIdentifierElement>().mapNotNull {
+            val name = it.name ?: return@mapNotNull null
+            name to it
+        }.groupBy({
+            it.first
+        }) {
+            TableGenIdentifierScopeNode.IdMapEntry(it.second)
+        }
+    }
+
+    override val directIdMap by myDirectIdMap
+
+    override fun subtreeChanged() {
+        super.subtreeChanged()
+        myDirectIdMap.reset()
+    }
 }

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenPsiImplUtil.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenPsiImplUtil.kt
@@ -6,7 +6,10 @@ import com.github.zero9178.mlirods.language.psi.*
 import com.github.zero9178.mlirods.language.psi.impl.TableGenPsiImplUtil.Companion.toString
 import com.github.zero9178.mlirods.language.stubs.impl.TableGenIdentifierElementStub
 import com.github.zero9178.mlirods.language.types.*
-import com.github.zero9178.mlirods.language.values.*
+import com.github.zero9178.mlirods.language.values.TableGenIntegerValue
+import com.github.zero9178.mlirods.language.values.TableGenStringValue
+import com.github.zero9178.mlirods.language.values.TableGenUnknownValue
+import com.github.zero9178.mlirods.language.values.TableGenValue
 import com.intellij.extapi.psi.ASTDelegatePsiElement
 import com.intellij.extapi.psi.ASTWrapperPsiElement
 import com.intellij.extapi.psi.StubBasedPsiElementBase
@@ -381,5 +384,25 @@ class TableGenPsiImplUtil {
             }
             return TableGenStringValue(res)
         }
+
+        @JvmStatic
+        fun getDirectIdMap(element: TableGenForeachOperatorValueNode): Map<String, List<TableGenIdentifierScopeNode.IdMapEntry>> =
+            buildMap {
+                element.iterator?.let {
+                    it.name?.let { name ->
+                        put(name, listOf(TableGenIdentifierScopeNode.IdMapEntry(it)))
+                    }
+                }
+            }
+
+        @JvmStatic
+        fun getDirectIdMap(element: TableGenFoldlOperatorValueNode): Map<String, List<TableGenIdentifierScopeNode.IdMapEntry>> =
+            buildMap {
+                listOfNotNull(element.iterator, element.accmulator).forEach {
+                    it.name?.let { name ->
+                        put(name, listOf(TableGenIdentifierScopeNode.IdMapEntry(it)))
+                    }
+                }
+            }
     }
 }

--- a/src/test/kotlin/com/github/zero9178/mlirods/ReferenceTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/ReferenceTest.kt
@@ -177,6 +177,16 @@ class ReferenceTest : BasePlatformTestCase() {
         assertEquals(element.name, "i")
     }
 
+    fun `test FieldDefResolutionLexical`() {
+        val element = doTest<TableGenDefvarStatement>()
+        assertEquals(element.name, "i")
+    }
+
+    fun `test FieldDefParentResolutionLexical`() {
+        val element = doTest<TableGenTemplateArgDecl>()
+        assertEquals(element.name, "i")
+    }
+
     fun `test ParentClassFieldDefResolution`() {
         val element = doTest<TableGenFieldBodyItem>()
         assertEquals(element.name, "i")

--- a/src/test/kotlin/com/github/zero9178/mlirods/TestUtil.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/TestUtil.kt
@@ -41,8 +41,6 @@ fun UsefulTestCase.installCompileCommands(
         fireEvents = true
     )
 
-    IndexingTestUtil.waitUntilIndexesAreReady(project)
-
     val list = map.toList() + additionalPropagation
     PlatformTestUtil.waitWhileBusy {
         list.any {
@@ -53,4 +51,6 @@ fun UsefulTestCase.installCompileCommands(
             else file.context.includePaths != it.second.paths
         }
     }
+
+    IndexingTestUtil.waitUntilIndexesAreReady(project)
 }

--- a/src/test/testData/references/FieldDefParentResolutionLexical.td
+++ b/src/test/testData/references/FieldDefParentResolutionLexical.td
@@ -1,0 +1,7 @@
+class Foo<int i>;
+
+class Bar {
+    int i = 0;
+}
+
+class Foobar<int i> : Foo<<caret>i>, Bar;

--- a/src/test/testData/references/FieldDefResolutionLexical.td
+++ b/src/test/testData/references/FieldDefResolutionLexical.td
@@ -1,0 +1,7 @@
+class A {
+    defvar i = 7;
+
+    defvar v = <caret>i;
+
+    int i = 5;
+}


### PR DESCRIPTION
The previous local identifier lookup always performed a walk of the Psi and was therefore always linear in complexity and did not support stubs well.

The new lookup now calculates a scope map which in most cases will be `O(1)`, or `O(log n)` where `n` is the number of elements with the same name (i.e. usually tiny).