### PR TITLE
[TableGen] Don't assume every child is within an identifier scope

### DIFF
--- a/src/main/kotlin/com/github/zero9178/mlirods/language/TableGen.bnf
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/TableGen.bnf
@@ -734,6 +734,7 @@ foreach_operator_value_node ::= '!foreach' '(' bang_operator_definition ',' valu
 
         getDirectIdMap
         getType
+        isWithinNewScope
     ]
     implements=[
         "com.github.zero9178.mlirods.language.psi.TableGenIdentifierScopeNode"
@@ -751,6 +752,7 @@ foldl_operator_value_node ::= '!foldl' '(' value_node ',' value_node ',' bang_op
 
         getDirectIdMap
         getType
+        isWithinNewScope
     ]
     implements=[
         "com.github.zero9178.mlirods.language.psi.TableGenIdentifierScopeNode"

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenIdentifierReference.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenIdentifierReference.kt
@@ -13,7 +13,6 @@ import com.intellij.psi.PsiReferenceBase
 import com.intellij.psi.ResolveResult
 import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.util.isAncestor
-import com.intellij.psi.util.parentOfType
 import com.intellij.psi.util.parents
 import com.intellij.util.concurrency.annotations.RequiresReadLock
 import com.intellij.util.containers.withPrevious
@@ -101,7 +100,7 @@ class TableGenIdentifierReference(element: TableGenIdentifierValueNode) :
         CachedValuesManager.getProjectPsiDependentCache(element) { element ->
             val name = element.identifier.text
 
-            val def = element.parentOfType<TableGenIdentifierScopeNode>()?.run {
+            val def = TableGenIdentifierScopeNode.getParentScope(element)?.run {
                 idMap[name]?.let { list ->
                     // Find the last element that occurs before 'element'.
                     // We can use binary search due to the lexicographical ordering.

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenPsiImplUtil.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenPsiImplUtil.kt
@@ -396,6 +396,9 @@ class TableGenPsiImplUtil {
             }
 
         @JvmStatic
+        fun isWithinNewScope(self: TableGenForeachOperatorValueNode, element: PsiElement) = element == self.body
+
+        @JvmStatic
         fun getDirectIdMap(element: TableGenFoldlOperatorValueNode): Map<String, List<TableGenIdentifierScopeNode.IdMapEntry>> =
             buildMap {
                 listOfNotNull(element.iterator, element.accmulator).forEach {
@@ -404,5 +407,9 @@ class TableGenPsiImplUtil {
                     }
                 }
             }
+
+        @JvmStatic
+        fun isWithinNewScope(self: TableGenFoldlOperatorValueNode, element: PsiElement) = element == self.body
+
     }
 }

--- a/src/test/kotlin/com/github/zero9178/mlirods/ReferenceTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/ReferenceTest.kt
@@ -231,6 +231,16 @@ class ReferenceTest : BasePlatformTestCase() {
         assertEquals(element.name, "i")
     }
 
+    fun `test ForeachDefvarResolutionIterable`() {
+        val element = doTest<TableGenDefvarStatement>()
+        assertEquals(element.name, "i")
+    }
+
+    fun `test ForeachDefvarResolutionIterableParent`() {
+        val element = doTest<TableGenDefvarStatement>()
+        assertEquals(element.name, "i")
+    }
+
     fun `test FoldlIteratorDefvarResolution`() {
         val element = doTest<TableGenBangOperatorDefinition>()
         assertEquals(element.name, "i")
@@ -239,6 +249,12 @@ class ReferenceTest : BasePlatformTestCase() {
     fun `test FoldlAccDefvarResolution`() {
         val element = doTest<TableGenBangOperatorDefinition>()
         assertEquals(element.name, "acc")
+    }
+
+
+    fun `test FoldlDefvarResolutionIterable`() {
+        val element = doTest<TableGenDefvarStatement>()
+        assertEquals(element.name, "i")
     }
 
     fun `test ParentMultiClassListResolution`() {

--- a/src/test/testData/references/FoldlDefvarResolutionIterable.td
+++ b/src/test/testData/references/FoldlDefvarResolutionIterable.td
@@ -1,0 +1,2 @@
+defvar i = [];
+defvar a = !foldl(0, <caret>i, acc, i, !add(acc, i));

--- a/src/test/testData/references/ForeachDefvarResolutionIterable.td
+++ b/src/test/testData/references/ForeachDefvarResolutionIterable.td
@@ -1,0 +1,2 @@
+defvar i = [];
+defvar a = !foreach(i, <caret>i, i);

--- a/src/test/testData/references/ForeachDefvarResolutionIterableParent.td
+++ b/src/test/testData/references/ForeachDefvarResolutionIterableParent.td
@@ -1,0 +1,2 @@
+defvar i = [];
+defvar a = !foreach(i, !foreach(i, <caret>i, i), i);


### PR DESCRIPTION
This is not true for elements such as `!foreach`. The behavior is now controllable through the `isWithinNewScope` method. A convenient `getParentScope` method implements the lookup logic.