### PR TITLE
[TableGen] Add inspection for redefined fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Added support for the `!sort` operator
 - Added support for the `!switch` operator, including validation of its case clauses and mandatory default value
+- Added an inspection reporting fields that redefine an existing field, with a quick fix to convert them into a `let` statement
 
 ## [0.13.0] - 2026-05-13
 

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/TableGen.bnf
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/TableGen.bnf
@@ -330,6 +330,7 @@ field_body_item ::= 'field'? type_node IDENTIFIER equals_value? ';' {
     implements=[
         "com.github.zero9178.mlirods.language.psi.TableGenFieldIdentifierNode"
         "com.github.zero9178.mlirods.language.psi.TableGenIdentifierElement"
+        "com.github.zero9178.mlirods.language.psi.impl.TableGenFieldBodyItemEx"
     ]
     methods=[
         field_identifier="IDENTIFIER"

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/inspection/TableGenRedefinedFieldInspection.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/inspection/TableGenRedefinedFieldInspection.kt
@@ -1,0 +1,61 @@
+package com.github.zero9178.mlirods.language.inspection
+
+import com.github.zero9178.mlirods.MyBundle
+import com.github.zero9178.mlirods.language.generated.psi.TableGenFieldBodyItem
+import com.github.zero9178.mlirods.language.generated.psi.TableGenVisitor
+import com.github.zero9178.mlirods.language.psi.TableGenRecord
+import com.github.zero9178.mlirods.language.psi.createLetBodyItem
+import com.github.zero9178.mlirods.language.stubs.disallowTreeLoading
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.util.parentOfType
+
+/**
+ * Reports a [TableGenFieldBodyItem] that redefines a field already defined by the enclosing scope or one of its base
+ * classes. While legal TableGen, redefining a field merely to assign it a new value is a code smell: a `let` statement
+ * conveys the intent of overriding an inherited field's value without shadowing its declaration.
+ */
+internal class TableGenRedefinedFieldInspection : LocalInspectionTool() {
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
+        object : TableGenVisitor<Unit>() {
+            override fun visitFieldBodyItem(element: TableGenFieldBodyItem) = disallowTreeLoading {
+                val definingField = element.definingFieldBodyItem
+                if (definingField == element)
+                    return@disallowTreeLoading
+
+                val fieldIdentifier = element.fieldIdentifier ?: return@disallowTreeLoading
+                val fieldName = definingField.fieldName ?: return@disallowTreeLoading
+                val parentRecordName = definingField.parentOfType<TableGenRecord>()?.name ?: "<anonymous>"
+                // The quick fix can only produce a 'let' statement if there is a value to assign.
+                val fix =
+                    if (element.valueNode != null) arrayOf(ConvertToLetQuickFix) else LocalQuickFix.EMPTY_ARRAY
+
+                holder.registerProblem(
+                    fieldIdentifier,
+                    MyBundle.message("tableGen.inspection.redefinedField.message", parentRecordName, fieldName),
+                    *fix
+                )
+            }
+        }
+}
+
+/**
+ * Replaces a field redefinition such as `int x = 5;` with the equivalent `let x = 5;` that overrides the inherited
+ * field's value instead of redeclaring it.
+ */
+object ConvertToLetQuickFix : LocalQuickFix {
+
+    override fun getFamilyName(): String = MyBundle.message("tableGen.inspection.redefinedField.quickFix")
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val field = descriptor.psiElement.parentOfType<TableGenFieldBodyItem>(true) ?: return
+        val fieldName = field.fieldName ?: return
+        val value = field.valueNode ?: return
+        field.replace(createLetBodyItem(project, fieldName, value.text))
+    }
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenElementFactories.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenElementFactories.kt
@@ -3,6 +3,7 @@ package com.github.zero9178.mlirods.language.psi
 import com.github.zero9178.mlirods.language.TableGenLanguage
 import com.github.zero9178.mlirods.language.generated.psi.TableGenDefvarStatement
 import com.github.zero9178.mlirods.language.generated.psi.TableGenIdentifierValueNode
+import com.github.zero9178.mlirods.language.generated.psi.TableGenLetBodyItem
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFileFactory
@@ -47,3 +48,13 @@ fun createIdentifierValueNode(project: Project, name: String): TableGenIdentifie
  */
 fun createIdentifier(project: Project, name: String) =
     (createFile(project, "defvar $name = $name;").firstChild as TableGenDefvarStatement).nameIdentifier!!
+
+/**
+ * Returns a [TableGenLetBodyItem] of the form `let [name] = [value];`.
+ */
+fun createLetBodyItem(project: Project, name: String, value: String): TableGenLetBodyItem {
+    return PsiTreeUtil.findChildOfType(
+        createFile(project, "class __dummy { let $name = $value; }"),
+        TableGenLetBodyItem::class.java
+    )!!
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenFieldScopeNode.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenFieldScopeNode.kt
@@ -5,8 +5,6 @@ import com.github.zero9178.mlirods.language.generated.psi.TableGenFieldBodyItem
 import com.github.zero9178.mlirods.language.stubs.disallowTreeLoading
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.CachedValuesManager
-import com.intellij.psi.util.endOffset
-import com.intellij.psi.util.startOffset
 
 /**
  * Map used to lookup fields within a [TableGenFieldScopeNode].
@@ -16,33 +14,33 @@ class FieldMap(private val myRoot: TableGenFieldScopeNode) {
 
     /**
      * Returns the field named [fieldName] within [myRoot] or null if no such field exists.
-     * If [element] is not null, null is returned if the field has not yet been defined at the location of [element].
+     * If there are multiple [TableGenFieldBodyItem] that define [fieldName], then the defining one is returned.
+     * If [beforeElement] is not null, null is returned if the field has not yet been defined at the location of
+     * [beforeElement].
      */
-    operator fun get(fieldName: String, element: PsiElement? = null): TableGenFieldBodyItem? = disallowTreeLoading {
-        val differentFile = myRoot.containingFile != element?.containingFile
+    operator fun get(fieldName: String, beforeElement: PsiElement? = null): TableGenFieldBodyItem? =
+        disallowTreeLoading {
+            // Only consider base classes referenced before 'beforeElement'.
+            myRoot.baseClassRefs.takeWhile {
+                beforeElement?.let { other -> it.isBefore(other) } ?: true
+            }.mapNotNull {
+                it.referencedClass
+            }.firstNotNullOfOrNull {
+                FieldMap(it)[fieldName, beforeElement]
+            }?.let { return@disallowTreeLoading it }
 
-        // Compute lazily as this performs a traversal up to the parent file.
-        val startOffset = lazy(LazyThreadSafetyMode.PUBLICATION) {
-            element?.startOffset ?: Int.MAX_VALUE
+            // Only consider fields defined before 'beforeElement'.
+            val field = myRoot.directFields[fieldName] ?: return@disallowTreeLoading null
+            when {
+                beforeElement == null -> field
+                field.isBefore(beforeElement) != false -> field
+                else -> null
+            }
         }
-
-        // Only consider fields defined before 'fieldName'.
-        myRoot.directFields[fieldName]?.let {
-            if (differentFile || it.endOffset < startOffset.value) return@disallowTreeLoading it
-        }
-
-        // Only consider base classes referenced before 'fieldName'.
-        myRoot.baseClassRefs.takeWhile {
-            differentFile || it.endOffset < startOffset.value
-        }.mapNotNull {
-            it.referencedClass
-        }.firstNotNullOfOrNull {
-            FieldMap(it)[fieldName, element]
-        }
-    }
 
     /**
-     * Returns the field named [fieldName] within [myRoot] or null if no such field exists.
+     * Returns the field named [fieldName] within [myRoot] or null if no such field exists yet at the location of
+     * [fieldName].
      */
     operator fun get(fieldName: PsiElement) = get(fieldName.text, fieldName)
 }
@@ -53,6 +51,7 @@ class FieldMap(private val myRoot: TableGenFieldScopeNode) {
 interface TableGenFieldScopeNode : TableGenIdentifierScopeNode {
     /**
      * Returns a map of all fields that are defined directly within this.
+     * If there is one or more field with the same name, the map contains the first occurrence.
      */
     val directFields: Map<String, TableGenFieldBodyItem>
 
@@ -64,21 +63,31 @@ interface TableGenFieldScopeNode : TableGenIdentifierScopeNode {
 
     /**
      * Returns a sequence of all fields of this class, including inherited fields.
+     * The field body items returned by this sequence are guaranteed to be the defining field body items.
      */
     val allFields: Sequence<TableGenFieldBodyItem>
-        get() = directFields.values.asSequence() + baseClassRefs.mapNotNull {
-            it.referencedClass
-        }.flatMap {
-            it.allFields
+        get() = sequence {
+            val seen = mutableSetOf<String?>()
+            baseClassRefs.mapNotNull {
+                it.referencedClass
+            }.flatMap {
+                it.allFields
+            }.forEach {
+                if (seen.add(it.fieldName))
+                    yield(it)
+            }
+
+            yieldAll(directFields.values.asSequence().filter {
+                !seen.contains(it.fieldName)
+            })
         }
 
     /**
      * Returns a map of all field assignments in order of application (earliest to latest), including from all
      * transitive base classes.
-     * The first element in a list is therefore always a field body item (if valid TableGen), followed by let body
-     * items.
+     * The first element in a list is therefore always a field body item if valid TableGen.
      */
-     val allFieldAssignments: Map<String, List<TableGenFieldIdentifierNode>>
+    val allFieldAssignments: Map<String, List<TableGenFieldIdentifierNode>>
         get() = CachedValuesManager.getProjectPsiDependentCache(this) {
             val result = directFieldAssignments.toMutableMap()
             baseClassRefs.toList().asReversed().mapNotNull { it.referencedClass }.map {

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/Util.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/Util.kt
@@ -24,3 +24,11 @@ fun PsiElement.compareTo(other: PsiElement): Int? {
 
     return startOffset.compareTo(other.startOffset)
 }
+
+/**
+ * Returns true if `this` is defined before [other].
+ * Returns null if the elements are in different files.
+ */
+fun PsiElement.isBefore(other: PsiElement): Boolean? = this.compareTo(other)?.let {
+    it == -1
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenFieldBodyItemEx.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenFieldBodyItemEx.kt
@@ -1,0 +1,14 @@
+package com.github.zero9178.mlirods.language.psi.impl
+
+import com.github.zero9178.mlirods.language.generated.psi.TableGenFieldBodyItem
+
+interface TableGenFieldBodyItemEx {
+
+    /**
+     * Returns the defining [TableGenFieldBodyItem] of this field.
+     * The defining [TableGenFieldBodyItem] is defined as the one which first defined the field within the record
+     * and therefore also determined its type.
+     * Returns `this` if `this` is the defining [TableGenFieldBodyItem].
+     */
+    val definingFieldBodyItem: TableGenFieldBodyItem
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenFieldBodyItemMixin.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenFieldBodyItemMixin.kt
@@ -1,12 +1,14 @@
 package com.github.zero9178.mlirods.language.psi.impl
 
 import com.github.zero9178.mlirods.language.generated.psi.TableGenFieldBodyItem
+import com.github.zero9178.mlirods.language.psi.TableGenFieldScopeNode
 import com.github.zero9178.mlirods.language.psi.createIdentifier
 import com.github.zero9178.mlirods.language.stubs.impl.TableGenFieldBodyItemStub
 import com.intellij.extapi.psi.StubBasedPsiElementBase
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
+import com.intellij.psi.util.parentOfType
 
 abstract class TableGenFieldBodyItemMixin : StubBasedPsiElementBase<TableGenFieldBodyItemStub>,
     TableGenFieldBodyItem {
@@ -36,4 +38,12 @@ abstract class TableGenFieldBodyItemMixin : StubBasedPsiElementBase<TableGenFiel
     override fun getTextOffset(): Int {
         return nameIdentifier?.textOffset ?: super.getTextOffset()
     }
+
+    override val definingFieldBodyItem: TableGenFieldBodyItem
+        get() {
+            val fieldName = fieldName ?: return this
+            val scope = parentOfType<TableGenFieldScopeNode>() ?: return this
+            // Only fields defined before this one (in this scope or a base class) constitute a redefinition.
+            return scope.fields[fieldName, this] ?: this
+        }
 }

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenRecordStatementMixin.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenRecordStatementMixin.kt
@@ -47,7 +47,7 @@ abstract class TableGenRecordStatementMixin<StubT : StubElement<*>> : StubBasedP
 
     private var myDirectFields = resettableLazy {
         directFieldAssignments.mapNotNull { (k, v) ->
-            val field = v.asReversed().firstNotNullOfOrNull {
+            val field = v.firstNotNullOfOrNull {
                 it as? TableGenFieldBodyItem
             } ?: return@mapNotNull null
             k to field

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -99,6 +99,15 @@
         <annotator language="TableGen"
                    implementationClass="com.github.zero9178.mlirods.language.annotator.TableGenSyntaxAnnotator"
         />
+        <localInspection language="TableGen"
+                         shortName="TableGenRedefinedField"
+                         bundle="messages.MyBundle"
+                         key="tableGen.inspection.redefinedField.displayName"
+                         groupKey="tableGen.inspection.group"
+                         enabledByDefault="true"
+                         level="WARNING"
+                         implementationClass="com.github.zero9178.mlirods.language.inspection.TableGenRedefinedFieldInspection"
+        />
     </extensions>
 
     <extensions defaultExtensionNs="com.intellij.platform.lsp">

--- a/src/main/resources/inspectionDescriptions/TableGenRedefinedField.html
+++ b/src/main/resources/inspectionDescriptions/TableGenRedefinedField.html
@@ -1,0 +1,26 @@
+<html>
+<body>
+Reports fields that redefine a field already declared by the enclosing class, definition or one of its base classes.
+<p>
+    Although legal TableGen, redeclaring an inherited field merely to give it a new value shadows the original
+    declaration and is a code smell. A <code>let</code> statement expresses the intent of overriding an inherited
+    field's value without redeclaring it.
+</p>
+<p><b>Example:</b></p>
+<pre><code>
+class Base {
+  int x = 0;
+}
+
+class Derived : Base {
+  int x = 1; // redefinition of 'x'
+}
+</code></pre>
+<p>After applying the quick fix:</p>
+<pre><code>
+class Derived : Base {
+  let x = 1;
+}
+</code></pre>
+</body>
+</html>

--- a/src/main/resources/messages/MyBundle.properties
+++ b/src/main/resources/messages/MyBundle.properties
@@ -13,3 +13,8 @@ tableGen.syntax.invalidLetMode=Expected one of ''append'' or ''prepend'' instead
 tableGen.syntax.switch.missingDefault='!switch' requires a default value as its last argument
 tableGen.syntax.switch.misplacedDefault=Only the last '!switch' argument may be the default; expected ':' followed by a value
 tableGen.syntax.switch.missingCase='!switch' requires at least one 'case : value' pair
+
+tableGen.inspection.group=TableGen
+tableGen.inspection.redefinedField.displayName=Field redefinition
+tableGen.inspection.redefinedField.message=Redefinition of existing field ''{0}:{1}''
+tableGen.inspection.redefinedField.quickFix=Convert to 'let' statement

--- a/src/test/kotlin/com/github/zero9178/mlirods/TableGenInspectionTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/TableGenInspectionTest.kt
@@ -1,0 +1,94 @@
+package com.github.zero9178.mlirods
+
+import com.github.zero9178.mlirods.language.inspection.ConvertToLetQuickFix
+import com.github.zero9178.mlirods.language.inspection.TableGenRedefinedFieldInspection
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+class TableGenInspectionTest : BasePlatformTestCase() {
+
+    override fun setUp() {
+        super.setUp()
+        myFixture.enableInspections(TableGenRedefinedFieldInspection::class.java)
+    }
+
+    fun `test no redefinition`() {
+        myFixture.configureByText(
+            "test.td", """
+            class Base {
+                int x = 0;
+            }
+
+            class Derived : Base {
+                int y = 1;
+            }
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test redefinition in same scope`() {
+        myFixture.configureByText(
+            "test.td", """
+            class F {
+                int x = 0;
+                int <warning descr="Redefinition of existing field 'F:x'">x</warning> = 1;
+            }
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test redefinition of inherited field`() {
+        myFixture.configureByText(
+            "test.td", """
+            class Base {
+                int x = 0;
+            }
+
+            class Derived : Base {
+                int <warning descr="Redefinition of existing field 'Base:x'">x</warning> = 1;
+            }
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test redefinition in anonymous record`() {
+        myFixture.configureByText(
+            "test.td", """
+            def {
+                int x = 0;
+                int <warning descr="Redefinition of existing field '<anonymous>:x'">x</warning> = 1;
+            }
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test convert to let quick fix`() {
+        myFixture.configureByText(
+            "test.td", """
+            class Base {
+                int x = 0;
+            }
+
+            class Derived : Base {
+                int x<caret> = 1;
+            }
+        """.trimIndent()
+        )
+        val intention = myFixture.findSingleIntention(ConvertToLetQuickFix.familyName)
+        myFixture.launchAction(intention)
+        myFixture.checkResult(
+            """
+            class Base {
+                int x = 0;
+            }
+
+            class Derived : Base {
+                let x = 1;
+            }
+        """.trimIndent()
+        )
+    }
+}


### PR DESCRIPTION
A field that redefines a field already declared by its record or an inherited base class is legal TableGen, but it is almost always unintentional: it shadows the original declaration and re-states the field's type just to assign a new value. The idiomatic way to override an inherited field's value is a `let` statement, which expresses that intent without redeclaring the field.

This PR therefore implements an inspection that marks this pattern as a warning. A quick fix is provided that rewrites the redefinition into the equivalent `let` statement.

Fixes https://github.com/zero9178/IntelliJ-MLIR-ODS/issues/225