### PR TITLE
[TableGen] Add error for positional arguments after named arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added support for the `!sort` operator
 - Added support for the `!switch` operator, including validation of its case clauses and mandatory default value
 - Added an inspection reporting fields that redefine an existing field, with a quick fix to convert them into a `let` statement
+- Added an error for positional arguments that follow a named argument in a class argument list
 
 ## [0.13.0] - 2026-05-13
 

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/TableGen.bnf
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/TableGen.bnf
@@ -790,7 +790,11 @@ class_instantiation_value_node ::= IDENTIFIER '<' arg_value_list? '>' {
 private arg_value_list ::= arg_value_item (',' arg_value_item)* {
     pin(".*") = 1
 }
-arg_value_item ::= value_node equals_value?
+arg_value_item ::= value_node equals_value? {
+    implements=[
+        "com.github.zero9178.mlirods.language.psi.impl.TableGenArgValueItemEx"
+    ]
+}
 
 // Special Psi node for variable definitions within bang operators.
 bang_operator_definition ::= IDENTIFIER {

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/annotator/TableGenAnnotationUtils.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/annotator/TableGenAnnotationUtils.kt
@@ -1,0 +1,29 @@
+package com.github.zero9178.mlirods.language.annotator
+
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.Annotator
+import com.intellij.psi.PsiElement
+
+/**
+ * Callback signature used in [TableGenAnnotator].
+ */
+typealias AnnotationCallback = (PsiElement, AnnotationHolder) -> Unit
+
+/**
+ * Creates an [AnnotationCallback] that calls [annotation] anytime an element of type [T] is encountered.
+ */
+inline fun <reified T : PsiElement> addAnnotationFor(crossinline annotation: (T, AnnotationHolder) -> Unit): AnnotationCallback =
+    { e, a ->
+        if (e is T) annotation(e, a)
+    }
+
+/**
+ * Base class for creating [Annotator]s that go through a list of annotation callbacks.
+ */
+abstract class TableGenAnnotator(private val annotations: Iterable<AnnotationCallback>) : Annotator {
+    override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+        annotations.forEach {
+            it(element, holder)
+        }
+    }
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/annotator/TableGenSyntaxAnnotator.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/annotator/TableGenSyntaxAnnotator.kt
@@ -1,36 +1,28 @@
 package com.github.zero9178.mlirods.language.annotator
 
 import com.github.zero9178.mlirods.MyBundle
+import com.github.zero9178.mlirods.language.generated.psi.TableGenAbstractClassRef
 import com.github.zero9178.mlirods.language.generated.psi.TableGenSwitchOperatorValueNode
 import com.github.zero9178.mlirods.language.psi.impl.TableGenAbstractLetItem
-import com.intellij.lang.annotation.AnnotationHolder
-import com.intellij.lang.annotation.Annotator
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.project.DumbAware
-import com.intellij.psi.PsiElement
 
-internal class TableGenSyntaxAnnotator : Annotator, DumbAware {
-    override fun annotate(element: PsiElement, holder: AnnotationHolder) {
-        when (element) {
-            is TableGenAbstractLetItem -> {
-                val letModeIdentifier = element.letModeIdentifier
-                if (letModeIdentifier != null && element.letMode == null) holder.newAnnotation(
-                    HighlightSeverity.ERROR, MyBundle.message("tableGen.syntax.invalidLetMode", letModeIdentifier.text)
-                ).range(letModeIdentifier).create()
-            }
-
-            is TableGenSwitchOperatorValueNode -> annotateSwitch(element, holder)
-        }
-    }
-
+private val ANNOTATIONS = arrayOf(
+    addAnnotationFor { element: TableGenAbstractLetItem, holder ->
+        val letModeIdentifier = element.letModeIdentifier
+        if (letModeIdentifier != null && element.letMode == null)
+            holder.newAnnotation(
+                HighlightSeverity.ERROR, MyBundle.message("tableGen.syntax.invalidLetMode", letModeIdentifier.text)
+            ).range(letModeIdentifier).create()
+    },
     /**
      * Verifies the grammar invariants of a `!switch` operator: there must be at least one `case : value` pair, every
      * clause but the last must be such a pair, and the last clause must be the mandatory default value (a clause without
      * a `:`).
      */
-    private fun annotateSwitch(element: TableGenSwitchOperatorValueNode, holder: AnnotationHolder) {
+    addAnnotationFor { element: TableGenSwitchOperatorValueNode, holder ->
         val clauses = element.switchClauseList
-        if (clauses.isEmpty()) return
+        if (clauses.isEmpty()) return@addAnnotationFor
 
         // Besides the trailing default value, at least one 'case : value' pair is mandatory.
         if (clauses.none { it.hasColon }) holder.newAnnotation(
@@ -51,5 +43,20 @@ internal class TableGenSyntaxAnnotator : Annotator, DumbAware {
                 ).range(clause).create()
             }
         }
-    }
-}
+    },
+    addAnnotationFor { element: TableGenAbstractClassRef, holder ->
+        // First drop all positional arguments, followed by all named arguments.
+        // If any arguments remain after, then there must have been a positional argument after a named argument.
+        element.argValueItemList.asSequence().dropWhile {
+            it.isPositionalArgument
+        }.dropWhile {
+            it.isNamedArgument
+        }.firstOrNull()?.let {
+            holder.newAnnotation(
+                HighlightSeverity.ERROR, MyBundle.message("tableGen.syntax.positionalAfterNamed")
+            ).range(it).create()
+        }
+    },
+)
+
+internal class TableGenSyntaxAnnotator : TableGenAnnotator(ANNOTATIONS.asIterable()), DumbAware

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenArgValueItemEx.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenArgValueItemEx.kt
@@ -1,0 +1,23 @@
+package com.github.zero9178.mlirods.language.psi.impl
+
+import com.github.zero9178.mlirods.language.generated.TableGenTypes
+import com.intellij.psi.PsiElement
+
+/**
+ * Interface used to inject methods into [com.github.zero9178.mlirods.language.generated.psi.TableGenArgValueItem].
+ */
+interface TableGenArgValueItemEx : PsiElement {
+
+    /**
+     * Returns whether this argument is a named argument of the form `name = value` rather than a positional argument.
+     */
+    val isNamedArgument: Boolean
+        get() = node.findChildByType(TableGenTypes.EQUALS) != null
+
+    /**
+     * Returns true if this argument us a positional argument. Note that this is mutually exclusive with
+     * [isNamedArgument].
+     */
+    val isPositionalArgument: Boolean
+        get() = !isNamedArgument
+}

--- a/src/main/resources/messages/MyBundle.properties
+++ b/src/main/resources/messages/MyBundle.properties
@@ -14,6 +14,8 @@ tableGen.syntax.switch.missingDefault='!switch' requires a default value as its 
 tableGen.syntax.switch.misplacedDefault=Only the last '!switch' argument may be the default; expected ':' followed by a value
 tableGen.syntax.switch.missingCase='!switch' requires at least one 'case : value' pair
 
+tableGen.syntax.positionalAfterNamed=Positional argument is not allowed after a named argument
+
 tableGen.inspection.group=TableGen
 tableGen.inspection.redefinedField.displayName=Field redefinition
 tableGen.inspection.redefinedField.message=Redefinition of existing field ''{0}:{1}''

--- a/src/test/kotlin/com/github/zero9178/mlirods/TableGenSyntaxAnnotatorTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/TableGenSyntaxAnnotatorTest.kt
@@ -82,4 +82,64 @@ class TableGenSyntaxAnnotatorTest : BasePlatformTestCase() {
         )
         myFixture.checkHighlighting()
     }
+
+    fun `test positional only arguments`() {
+        myFixture.configureByText(
+            "test.td", """
+            class C<int a, int b>;
+            defvar v = C<1, 2>;
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test named only arguments`() {
+        myFixture.configureByText(
+            "test.td", """
+            class C<int a, int b>;
+            defvar v = C<a = 1, b = 2>;
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test positional before named arguments`() {
+        myFixture.configureByText(
+            "test.td", """
+            class C<int a, int b>;
+            defvar v = C<1, b = 2>;
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test positional after named argument`() {
+        myFixture.configureByText(
+            "test.td", """
+            class C<int a, int b>;
+            defvar v = C<a = 1, <error descr="Positional argument is not allowed after a named argument">2</error>>;
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test class ref positional before named arguments`() {
+        myFixture.configureByText(
+            "test.td", """
+            class C<int a, int b>;
+            def D : C<1, b = 2>;
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test class ref positional after named argument`() {
+        myFixture.configureByText(
+            "test.td", """
+            class C<int a, int b>;
+            def D : C<a = 1, <error descr="Positional argument is not allowed after a named argument">2</error>>;
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
 }


### PR DESCRIPTION
In a class argument list (both class instantiations such as `C<...>` and parent class references such as `def D : C<...>`) a positional argument may not follow a named `name = value` argument. Report such arguments as an error so the mistake is caught in the editor rather than only by `tblgen`.