### PR TITLE
[TableGen] Add reference resolution and renaming for named arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added an inspection reporting fields that redefine an existing field, with a quick fix to convert them into a `let` statement
 - Added an error for positional arguments that follow a named argument in a class argument list
 - Added distinct syntax highlighting for named arguments in a class argument list
+- Added reference resolution and renaming for named arguments in a class argument list
 
 ## [0.13.0] - 2026-05-13
 

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenArgValueItemManipulator.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenArgValueItemManipulator.kt
@@ -1,0 +1,26 @@
+package com.github.zero9178.mlirods.language.psi
+
+import com.github.zero9178.mlirods.language.generated.psi.TableGenArgValueItem
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.AbstractElementManipulator
+
+internal class TableGenArgValueItemManipulator : AbstractElementManipulator<TableGenArgValueItem>() {
+
+    override fun handleContentChange(
+        element: TableGenArgValueItem, range: TextRange, newContent: String
+    ): TableGenArgValueItem? {
+        val identifier = element.identifier ?: return null
+
+        val newName = range.shiftLeft(getRangeInElement(element).startOffset).replace(identifier.text, newContent)
+        identifier.replace(createIdentifier(element.project, newName))
+        return element
+    }
+
+    /**
+     * Returns the text range that can be manipulated.
+     * Returns the range of the string literal excluding quotes.
+     */
+    override fun getRangeInElement(element: TableGenArgValueItem): TextRange {
+        return element.identifier?.textRangeInParent ?: TextRange.EMPTY_RANGE
+    }
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenArgValueItemReference.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenArgValueItemReference.kt
@@ -1,0 +1,64 @@
+package com.github.zero9178.mlirods.language.psi
+
+import com.github.zero9178.mlirods.language.generated.psi.TableGenAbstractClassRef
+import com.github.zero9178.mlirods.language.generated.psi.TableGenArgValueItem
+import com.github.zero9178.mlirods.language.psi.impl.TableGenEvaluationContext
+import com.github.zero9178.mlirods.language.stubs.disallowTreeLoading
+import com.github.zero9178.mlirods.language.values.TableGenStringValue
+import com.intellij.psi.PsiElementResolveResult
+import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.ResolveResult
+import com.intellij.psi.util.CachedValuesManager
+import com.intellij.psi.util.parentOfType
+import com.intellij.util.concurrency.annotations.RequiresReadLock
+
+
+class TableGenArgValueItemReference(element: TableGenArgValueItem) :
+    PsiReferenceBase.Poly<TableGenArgValueItem>(element) {
+
+    override fun hashCode(): Int {
+        return element.hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return element === (other as? TableGenArgValueItemReference)?.element
+    }
+
+    @RequiresReadLock
+    override fun multiResolve(incompleteCode: Boolean): Array<out ResolveResult> =
+        CachedValuesManager.getProjectPsiDependentCache(element) {
+            disallowTreeLoading {
+                val classRef = element.parentOfType<TableGenAbstractClassRef>()
+                    ?: return@disallowTreeLoading emptyArray<ResolveResult>()
+                val targetClass = classRef.referencedClass ?: return@disallowTreeLoading emptyArray<ResolveResult>()
+
+                val templateArg = if (element.isNamedArgument) {
+                    val identifierName = element.identifierName
+                    val nameNode = element.nameNode
+                    val argumentName = when {
+                        identifierName != null -> identifierName
+                        nameNode != null -> when (val result = nameNode.evaluate(TableGenEvaluationContext())) {
+                            is TableGenStringValue -> result.value
+                            else -> return@disallowTreeLoading emptyArray<ResolveResult>()
+                        }
+
+                        else -> return@disallowTreeLoading emptyArray<ResolveResult>()
+                    }
+                    targetClass.templateArgDeclList.find {
+                        it.name == argumentName
+                    }
+                } else {
+                    val index = classRef.argValueItemList.binarySearchBy(element.startOffsetInParent) {
+                        it.startOffsetInParent
+                    }
+                    assert(index >= 0) {
+                        "element should be guaranteed to be within the arg-value item list"
+                    }
+                    targetClass.templateArgDeclList.getOrNull(index)
+                }
+                if (templateArg == null) return@disallowTreeLoading emptyArray<ResolveResult>()
+
+                arrayOf(PsiElementResolveResult(templateArg))
+            }
+        }
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenArgValueItemEx.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenArgValueItemEx.kt
@@ -1,11 +1,14 @@
 package com.github.zero9178.mlirods.language.psi.impl
 
+import com.github.zero9178.mlirods.language.generated.psi.TableGenTemplateArgDecl
+import com.github.zero9178.mlirods.language.generated.psi.TableGenValueNode
+import com.intellij.psi.NavigatablePsiElement
 import com.intellij.psi.PsiElement
 
 /**
  * Interface used to inject methods into [com.github.zero9178.mlirods.language.generated.psi.TableGenArgValueItem].
  */
-interface TableGenArgValueItemEx : PsiElement {
+interface TableGenArgValueItemEx : PsiElement, NavigatablePsiElement {
 
     /**
      * Returns whether this argument is a named argument of the form `name = value` rather than a positional argument.
@@ -18,4 +21,25 @@ interface TableGenArgValueItemEx : PsiElement {
      */
     val isPositionalArgument: Boolean
         get() = !isNamedArgument
+
+    /**
+     * Returns the value that is assigned to a given argument if present.
+     */
+    val valueNode: TableGenValueNode?
+
+    /**
+     * Returns the name that is assigned to a given argument if present.
+     * Note that a name may also just be an identifier instead.
+     */
+    val nameNode: TableGenValueNode?
+
+    /**
+     * If this is a named argument with an identifier as name, returns the name from that identifier.
+     */
+    val identifierName: String?
+
+    /**
+     * Returns the [TableGenTemplateArgDecl] that this item assigns a value to if possible.
+     */
+    val referencedTemplateArgDecl: TableGenTemplateArgDecl?
 }

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenArgValueItemMixin.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenArgValueItemMixin.kt
@@ -1,6 +1,9 @@
 package com.github.zero9178.mlirods.language.psi.impl
 
 import com.github.zero9178.mlirods.language.generated.psi.TableGenArgValueItem
+import com.github.zero9178.mlirods.language.generated.psi.TableGenTemplateArgDecl
+import com.github.zero9178.mlirods.language.generated.psi.TableGenValueNode
+import com.github.zero9178.mlirods.language.psi.TableGenArgValueItemReference
 import com.github.zero9178.mlirods.language.stubs.impl.TableGenArgValueItemStub
 import com.intellij.extapi.psi.StubBasedPsiElementBase
 import com.intellij.lang.ASTNode
@@ -12,6 +15,28 @@ abstract class TableGenArgValueItemMixin : StubBasedPsiElementBase<TableGenArgVa
 
     constructor(stub: TableGenArgValueItemStub, stubType: IStubElementType<*, *>) : super(stub, stubType)
 
+    override fun getReference() =
+        // Only allow navigation in the UI if it is a named argument.
+        if (isNamedArgument) TableGenArgValueItemReference(this) else null
+
     override val isNamedArgument: Boolean
         get() = greenStub?.isNamedArgument ?: (equalsSign != null)
+
+    override val nameNode: TableGenValueNode?
+        get() = if (isNamedArgument) valueNodeList.firstOrNull() else null
+
+    override val valueNode: TableGenValueNode?
+        get() = if (isNamedArgument) valueNodeList.getOrNull(1) else valueNodeList.firstOrNull()
+
+    override val referencedTemplateArgDecl: TableGenTemplateArgDecl?
+        get() = TableGenArgValueItemReference(this).resolve() as? TableGenTemplateArgDecl
+
+    override val identifierName: String?
+        get() {
+            greenStub?.let {
+                return it.identifier
+            }
+
+            return identifier?.text
+        }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -55,6 +55,9 @@
         <lang.elementManipulator
                 forClass="com.github.zero9178.mlirods.language.generated.psi.TableGenFieldAccessValueNode"
                 implementationClass="com.github.zero9178.mlirods.language.psi.TableGenFieldAccessValueNodeManipulator"/>
+        <lang.elementManipulator
+                forClass="com.github.zero9178.mlirods.language.generated.psi.TableGenArgValueItem"
+                implementationClass="com.github.zero9178.mlirods.language.psi.TableGenArgValueItemManipulator"/>
         <stubElementTypeHolder class="com.github.zero9178.mlirods.language.stubs.TableGenStubElementTypes"
                                externalIdPrefix="tablegen."/>
         <stubIndex implementation="com.github.zero9178.mlirods.index.TableGenIdentifierIndex"/>

--- a/src/test/kotlin/com/github/zero9178/mlirods/ReferenceTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/ReferenceTest.kt
@@ -4,6 +4,7 @@ import com.github.zero9178.mlirods.language.generated.psi.*
 import com.github.zero9178.mlirods.model.IncludePaths
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.parentOfType
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.testFramework.utils.vfs.deleteRecursively
@@ -344,7 +345,7 @@ class ReferenceTest : BasePlatformTestCase() {
             """
             class F {
                 list<int> i = [];
-            
+
                 let append <caret>i = [10];
             }
         """.trimIndent()
@@ -352,8 +353,99 @@ class ReferenceTest : BasePlatformTestCase() {
         assertEquals("i", iter.name)
     }
 
+    fun `test named arg identifier resolution`() {
+        val element = doTestInline<TableGenTemplateArgDecl>(
+            """
+            class F<int i, int j>;
+
+            def : F<<caret>i = 0, j = 1>;
+        """.trimIndent()
+        )
+        assertEquals("i", element.name)
+        assertEquals("F", element.parentOfType<TableGenClassStatement>()?.name)
+    }
+
+    fun `test named arg identifier resolution out of order`() {
+        // Named arguments resolve by name, not position.
+        val element = doTestInline<TableGenTemplateArgDecl>(
+            """
+            class F<int i, int j>;
+
+            def : F<j = 1, <caret>i = 0>;
+        """.trimIndent()
+        )
+        assertEquals("i", element.name)
+    }
+
+    fun `test positional arg resolution`() {
+        // Positional arguments resolve by index and do not expose a UI reference.
+        val item = argValueItem(
+            """
+            class F<int i, int j>;
+
+            def : F<10, 20>;
+        """.trimIndent(),
+            1
+        )
+        assertNull(item.reference)
+        assertEquals("j", item.referencedTemplateArgDecl?.name)
+    }
+
+    fun `test named string arg resolution`() {
+        // A named argument may use a string literal instead of an identifier as the name.
+        val item = argValueItem(
+            """
+            class F<int i, int j>;
+
+            def : F<"j" = 20>;
+        """.trimIndent(),
+            0
+        )
+        assertEquals("j", item.referencedTemplateArgDecl?.name)
+    }
+
+    fun `test named arg has reference`() {
+        val item = argValueItem(
+            """
+            class F<int i>;
+
+            def : F<i = 0>;
+        """.trimIndent(),
+            0
+        )
+        assertNotNull(item.reference)
+        assertEquals("i", (item.reference?.resolve() as? TableGenTemplateArgDecl)?.name)
+    }
+
+    fun `test unresolved named arg`() {
+        val item = argValueItem(
+            """
+            class F<int i>;
+
+            def : F<unknown = 0>;
+        """.trimIndent(),
+            0
+        )
+        assertNull(item.referencedTemplateArgDecl)
+    }
+
     override fun getTestDataPath(): String? {
         return "src/test/testData/references"
+    }
+
+    /**
+     * Returns the [index]-th [TableGenArgValueItem] of the last class reference in [source].
+     */
+    private fun argValueItem(source: String, index: Int): TableGenArgValueItem {
+        val file = myFixture.configureByText("test.td", source)
+        installCompileCommands(
+            project, mapOf(
+                file.virtualFile to IncludePaths(emptyList())
+            )
+        )
+        myFixture.configureFromExistingVirtualFile(file.virtualFile)
+        val items = PsiTreeUtil.findChildrenOfType(myFixture.file, TableGenArgValueItem::class.java).toList()
+        return items[index]
     }
 
     private inline fun <reified T> doTest(vararg additionalFiles: String): T {

--- a/src/test/kotlin/com/github/zero9178/mlirods/RenameTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/RenameTest.kt
@@ -55,6 +55,36 @@ class RenameTest : BasePlatformTestCase() {
         doTest("j")
     }
 
+    fun `test rename named arg`() {
+        // Renaming a template argument must update the named argument identifier via the manipulator.
+        doTestInline(
+            "j",
+            """
+            class F<int <caret>i>;
+
+            def : F<i = 0>;
+        """.trimIndent(),
+            """
+            class F<int j>;
+
+            def : F<j = 0>;
+        """.trimIndent()
+        )
+    }
+
+    private fun doTestInline(newName: String, source: String, expected: String) {
+        val mainVF = myFixture.createFile("test.td", source)
+        installCompileCommands(
+            project, mapOf(
+                mainVF to IncludePaths(emptyList())
+            )
+        )
+
+        myFixture.configureFromExistingVirtualFile(mainVF)
+        myFixture.renameElementAtCaret(newName)
+        myFixture.checkResult(expected)
+    }
+
     private fun doTest(newName: String) {
         val name = getTestName(false).trim()
 


### PR DESCRIPTION
Implement a reference and element manipulator for `arg_value_item` so that named arguments in a class argument list resolve to their template argument declaration and can be renamed/found via find-usages.