### PR TITLE
[TableGen] Validate class argument lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added an error for positional arguments that follow a named argument in a class argument list
 - Added distinct syntax highlighting for named arguments in a class argument list
 - Added reference resolution and renaming for named arguments in a class argument list
+- Added errors for invalid class argument lists: duplicate arguments, unknown or excess arguments, and missing required arguments
 
 ## [0.13.0] - 2026-05-13
 

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/annotator/TableGenSemanticAnnotator.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/annotator/TableGenSemanticAnnotator.kt
@@ -1,0 +1,69 @@
+package com.github.zero9178.mlirods.language.annotator
+
+import com.github.zero9178.mlirods.MyBundle
+import com.github.zero9178.mlirods.language.generated.psi.TableGenAbstractClassRef
+import com.github.zero9178.mlirods.language.generated.psi.TableGenArgValueItem
+import com.github.zero9178.mlirods.language.generated.psi.TableGenClassInstantiationValueNode
+import com.github.zero9178.mlirods.language.generated.psi.TableGenClassRef
+import com.github.zero9178.mlirods.language.generated.psi.TableGenTemplateArgDecl
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.HighlightSeverity
+
+/**
+ * Validates that the arguments passed to a class reference match its template argument declarations:
+ * 1. No template argument is assigned more than once.
+ * 2. Every argument resolves to a template argument declaration.
+ * 3. Every template argument declaration without a default value is assigned a value.
+ */
+private fun checkArguments(element: TableGenAbstractClassRef, holder: AnnotationHolder) {
+    val targetClass = element.referencedClass ?: return
+
+    // Map each referenced declaration to the arguments assigning a value to it.
+    val itemsByDecl = mutableMapOf<TableGenTemplateArgDecl, MutableList<TableGenArgValueItem>>()
+    for (item in element.argValueItemList) {
+        val decl = item.referencedTemplateArgDecl
+        if (decl != null) {
+            itemsByDecl.getOrPut(decl) { mutableListOf() }.add(item)
+            continue
+        }
+
+        // 2.) Every argument must reference a template argument declaration.
+        val message = if (item.isNamedArgument) {
+            MyBundle.message(
+                "tableGen.syntax.unknownNamedArgument", targetClass.name ?: "", item.identifierName ?: ""
+            )
+        } else {
+            MyBundle.message(
+                "tableGen.syntax.tooManyArguments", targetClass.name ?: "", targetClass.templateArgDeclList.size
+            )
+        }
+        holder.newAnnotation(HighlightSeverity.ERROR, message).range(item).create()
+    }
+
+    // 1.) A template argument must not be assigned more than once; only flag the redundant later assignments.
+    for ((decl, items) in itemsByDecl) {
+        items.drop(1).forEach {
+            holder.newAnnotation(
+                HighlightSeverity.ERROR, MyBundle.message("tableGen.syntax.duplicateArgument", decl.name ?: "")
+            ).range(it).create()
+        }
+    }
+
+    // 3.) Every template argument without a default value must be assigned a value.
+    for (decl in targetClass.templateArgDeclList) {
+        if (decl.valueNode != null || decl in itemsByDecl) continue
+
+        holder.newAnnotation(
+            HighlightSeverity.ERROR, MyBundle.message("tableGen.syntax.missingArgument", decl.name ?: "")
+        ).range(element.classIdentifier).create()
+    }
+}
+
+private val ANNOTATIONS = arrayOf(
+    // Only validate arguments for class references in an inheritance list and for class instantiations; other
+    // references (such as a class used as a type) do not pass template arguments.
+    addAnnotationFor { element: TableGenClassRef, holder -> checkArguments(element, holder) },
+    addAnnotationFor { element: TableGenClassInstantiationValueNode, holder -> checkArguments(element, holder) },
+)
+
+internal class TableGenSemanticAnnotator : TableGenAnnotator(ANNOTATIONS.asIterable())

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -102,6 +102,9 @@
         <annotator language="TableGen"
                    implementationClass="com.github.zero9178.mlirods.language.annotator.TableGenSyntaxAnnotator"
         />
+        <annotator language="TableGen"
+                   implementationClass="com.github.zero9178.mlirods.language.annotator.TableGenSemanticAnnotator"
+        />
         <localInspection language="TableGen"
                          shortName="TableGenRedefinedField"
                          bundle="messages.MyBundle"

--- a/src/main/resources/messages/MyBundle.properties
+++ b/src/main/resources/messages/MyBundle.properties
@@ -16,6 +16,11 @@ tableGen.syntax.switch.missingCase='!switch' requires at least one 'case : value
 
 tableGen.syntax.positionalAfterNamed=Positional argument is not allowed after a named argument
 
+tableGen.syntax.duplicateArgument=Template argument ''{0}'' is assigned more than once
+tableGen.syntax.unknownNamedArgument=Class ''{0}'' has no template argument named ''{1}''
+tableGen.syntax.tooManyArguments=Too many arguments for class ''{0}''; expected at most {1}
+tableGen.syntax.missingArgument=Missing value for required template argument ''{0}''
+
 tableGen.inspection.group=TableGen
 tableGen.inspection.redefinedField.displayName=Field redefinition
 tableGen.inspection.redefinedField.message=Redefinition of existing field ''{0}:{1}''

--- a/src/test/kotlin/com/github/zero9178/mlirods/TableGenSyntaxAnnotatorTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/TableGenSyntaxAnnotatorTest.kt
@@ -1,5 +1,6 @@
 package com.github.zero9178.mlirods
 
+import com.github.zero9178.mlirods.model.IncludePaths
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 
 class TableGenSyntaxAnnotatorTest : BasePlatformTestCase() {
@@ -139,6 +140,104 @@ class TableGenSyntaxAnnotatorTest : BasePlatformTestCase() {
             class C<int a, int b>;
             def D : C<a = 1, <error descr="Positional argument is not allowed after a named argument">2</error>>;
         """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test all required arguments provided`() {
+        doResolvingTest(
+            """
+            class C<int a, int b>;
+            def D : C<1, 2>;
+        """.trimIndent()
+        )
+    }
+
+    fun `test default arguments may be omitted`() {
+        doResolvingTest(
+            """
+            class C<int a, int b = 0>;
+            def D : C<1>;
+        """.trimIndent()
+        )
+    }
+
+    fun `test duplicate named argument`() {
+        doResolvingTest(
+            """
+            class C<int a, int b = 0>;
+            def D : C<a = 1, <error descr="Template argument 'a' is assigned more than once">a = 2</error>>;
+        """.trimIndent()
+        )
+    }
+
+    fun `test duplicate positional and named argument`() {
+        doResolvingTest(
+            """
+            class C<int a, int b = 0>;
+            def D : C<1, <error descr="Template argument 'a' is assigned more than once">a = 2</error>>;
+        """.trimIndent()
+        )
+    }
+
+    fun `test unknown named argument`() {
+        doResolvingTest(
+            """
+            class C<int a = 0>;
+            def D : C<<error descr="Class 'C' has no template argument named 'b'">b = 1</error>>;
+        """.trimIndent()
+        )
+    }
+
+    fun `test too many positional arguments`() {
+        doResolvingTest(
+            """
+            class C<int a, int b>;
+            def D : C<1, 2, <error descr="Too many arguments for class 'C'; expected at most 2">3</error>>;
+        """.trimIndent()
+        )
+    }
+
+    fun `test missing required argument`() {
+        doResolvingTest(
+            """
+            class C<int a>;
+            def D : <error descr="Missing value for required template argument 'a'">C</error>;
+        """.trimIndent()
+        )
+    }
+
+    fun `test class used as type is not validated`() {
+        // A class referenced as a field type does not pass template arguments and must not be flagged.
+        doResolvingTest(
+            """
+            class C<int a>;
+            class D { C f; }
+        """.trimIndent()
+        )
+    }
+
+    fun `test class with decl`() {
+        doResolvingTest(
+            """
+            class C;
+            
+            class C<int a>;
+            
+            class D : C<0>;
+        """.trimIndent()
+        )
+    }
+
+    /**
+     * Highlighting test that additionally installs compile commands so that class references resolve.
+     */
+    private fun doResolvingTest(source: String) {
+        val file = myFixture.configureByText("test.td", source)
+        installCompileCommands(
+            project, mapOf(
+                file.virtualFile to IncludePaths(emptyList())
+            )
         )
         myFixture.checkHighlighting()
     }


### PR DESCRIPTION
Add a semantic annotator that checks the arguments of class instantiations and inheritance-list references against the referenced class's template argument declarations:

- no template argument is assigned more than once,
- every argument resolves to a template argument declaration,
- every template argument without a default value is assigned a value.

A class used as a type is left unvalidated since it passes no arguments.