### PR TITLE
[TableGen] Diagnose unknown bang operators and validate their arity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 
+- Added errors for unknown bang operators and for bang operators given the wrong number of arguments
 - Added support for the `!sort` operator
 - Added support for the `!switch` operator, including validation of its case clauses and mandatory default value
 - Added an inspection reporting fields that redefine an existing field, with a quick fix to convert them into a `let` statement

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/annotator/TableGenSyntaxAnnotator.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/annotator/TableGenSyntaxAnnotator.kt
@@ -2,12 +2,43 @@ package com.github.zero9178.mlirods.language.annotator
 
 import com.github.zero9178.mlirods.MyBundle
 import com.github.zero9178.mlirods.language.generated.psi.TableGenAbstractClassRef
+import com.github.zero9178.mlirods.language.generated.psi.TableGenBangOperatorValueNode
 import com.github.zero9178.mlirods.language.generated.psi.TableGenSwitchOperatorValueNode
 import com.github.zero9178.mlirods.language.psi.impl.TableGenAbstractLetItem
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.project.DumbAware
 
 private val ANNOTATIONS = arrayOf(
+    addAnnotationFor { element: TableGenBangOperatorValueNode, holder ->
+        val operator = element.operator
+        if (operator == null) {
+            // Flag bang operators that are not one of the operators known to TableGen.
+            holder.newAnnotation(
+                HighlightSeverity.ERROR, MyBundle.message("tableGen.syntax.unknownBangOperator", element.operatorName)
+            ).range(element.bangOperator).create()
+            return@addAnnotationFor
+        }
+
+        // Flag a known operator that is given the wrong number of operands.
+        val arity = operator.arity
+        val count = element.valueNodeList.size
+        if (count in arity) return@addAnnotationFor
+
+        val message = when {
+            arity.first == arity.last -> MyBundle.message(
+                "tableGen.syntax.bangOperator.argCount.exactly", element.operatorName, arity.first, count
+            )
+
+            arity.last == Int.MAX_VALUE -> MyBundle.message(
+                "tableGen.syntax.bangOperator.argCount.atLeast", element.operatorName, arity.first, count
+            )
+
+            else -> MyBundle.message(
+                "tableGen.syntax.bangOperator.argCount.range", element.operatorName, arity.first, arity.last, count
+            )
+        }
+        holder.newAnnotation(HighlightSeverity.ERROR, message).range(element).create()
+    },
     addAnnotationFor { element: TableGenAbstractLetItem, holder ->
         val letModeIdentifier = element.letModeIdentifier
         if (letModeIdentifier != null && element.letMode == null)

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenBangOperator.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenBangOperator.kt
@@ -1,0 +1,90 @@
+package com.github.zero9178.mlirods.language.psi
+
+/**
+ * Enumeration of the bang operators parsed as a generic 'bang_operator_value_node'.
+ *
+ * This is the set of bang operators known to TableGen, minus those that have their own dedicated token and PSI node and
+ * are therefore parsed specially.
+ *
+ * The [operatorName] is the full operator token text including the leading '!'. [arity] is the range of allowed operand
+ * counts (the values inside the parentheses; a leading '<type>' is not an operand). Operators whose arguments are folded
+ * left-associatively (e.g. '!add') accept any number of operands greater than or equal to two.
+ */
+enum class TableGenBangOperator(val operatorName: String, val arity: IntRange) {
+    // Comparison.
+    EQ("!eq", 2..2),
+    NE("!ne", 2..2),
+    LE("!le", 2..2),
+    LT("!lt", 2..2),
+    GE("!ge", 2..2),
+    GT("!gt", 2..2),
+
+    // Control flow.
+    IF("!if", 3..3),
+
+    // Type and value queries.
+    ISA("!isa", 1..1),
+    EXISTS("!exists", 1..1),
+    INITIALIZED("!initialized", 1..1),
+    INSTANCES("!instances", 0..1),
+    REPR("!repr", 1..1),
+
+    // Arithmetic and bitwise.
+    ADD("!add", 2..Int.MAX_VALUE),
+    SUB("!sub", 2..2),
+    MUL("!mul", 2..Int.MAX_VALUE),
+    DIV("!div", 2..2),
+    NOT("!not", 1..1),
+    LOGTWO("!logtwo", 1..1),
+    AND("!and", 2..Int.MAX_VALUE),
+    OR("!or", 2..Int.MAX_VALUE),
+    XOR("!xor", 2..Int.MAX_VALUE),
+    SHL("!shl", 2..2),
+    SRA("!sra", 2..2),
+    SRL("!srl", 2..2),
+
+    // List operations.
+    HEAD("!head", 1..1),
+    TAIL("!tail", 1..1),
+    SIZE("!size", 1..1),
+    EMPTY("!empty", 1..1),
+    RANGE("!range", 1..3),
+    FILTER("!filter", 3..3),
+    LISTCONCAT("!listconcat", 2..Int.MAX_VALUE),
+    LISTFLATTEN("!listflatten", 1..1),
+    LISTSPLAT("!listsplat", 2..2),
+    LISTREMOVE("!listremove", 2..2),
+    INTERLEAVE("!interleave", 2..2),
+
+    // String operations.
+    STRCONCAT("!strconcat", 2..Int.MAX_VALUE),
+    SUBST("!subst", 3..3),
+    SUBSTR("!substr", 2..3),
+    FIND("!find", 2..3),
+    TOLOWER("!tolower", 1..1),
+    TOUPPER("!toupper", 1..1),
+    MATCH("!match", 2..2),
+
+    // DAG operations.
+    DAG("!dag", 3..3),
+    CON("!con", 2..Int.MAX_VALUE),
+    GETDAGOP("!getdagop", 1..1),
+    SETDAGOP("!setdagop", 2..2),
+    GETDAGOPNAME("!getdagopname", 1..1),
+    SETDAGOPNAME("!setdagopname", 2..2),
+    GETDAGARG("!getdagarg", 2..2),
+    SETDAGARG("!setdagarg", 3..3),
+    GETDAGNAME("!getdagname", 2..2),
+    SETDAGNAME("!setdagname", 3..3),
+    ;
+
+    companion object {
+        private val byOperatorName = entries.associateBy(TableGenBangOperator::operatorName)
+
+        /**
+         * Returns the [TableGenBangOperator] with the given full operator token text (e.g. '!div'),
+         * or null if no such bang operator exists.
+         */
+        fun fromOperatorName(operatorName: String): TableGenBangOperator? = byOperatorName[operatorName]
+    }
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenValueNodeEx.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenValueNodeEx.kt
@@ -1,13 +1,7 @@
 package com.github.zero9178.mlirods.language.psi.impl
 
-import com.github.zero9178.mlirods.language.generated.psi.TableGenDefStatement
-import com.github.zero9178.mlirods.language.generated.psi.TableGenFieldBodyItem
-import com.github.zero9178.mlirods.language.generated.psi.TableGenLetBodyItem
-import com.github.zero9178.mlirods.language.generated.psi.TableGenLetItem
-import com.github.zero9178.mlirods.language.generated.psi.TableGenTemplateArgDecl
-import com.github.zero9178.mlirods.language.generated.psi.TableGenValueNode
-import com.github.zero9178.mlirods.language.generated.psi.TableGenVisitor
-import com.github.zero9178.mlirods.language.psi.TableGenFieldScopeNode
+import com.github.zero9178.mlirods.language.generated.psi.*
+import com.github.zero9178.mlirods.language.psi.TableGenBangOperator
 import com.github.zero9178.mlirods.language.stubs.impl.TableGenBoolValueNodeStub
 import com.github.zero9178.mlirods.language.stubs.impl.TableGenIntegerValueNodeStub
 import com.github.zero9178.mlirods.language.stubs.impl.TableGenStringValueNodeStub
@@ -18,7 +12,6 @@ import com.github.zero9178.mlirods.language.values.TableGenStringValue
 import com.github.zero9178.mlirods.language.values.TableGenUnknownValue
 import com.github.zero9178.mlirods.language.values.TableGenValue
 import com.intellij.psi.PsiElement
-import com.intellij.psi.util.CachedValuesManager
 
 /**
  * Class passed around as context during a constant evaluation.
@@ -94,6 +87,12 @@ interface TableGenBangOperatorValueNodeEx : TableGenValueNodeEx {
      * The bang operator token text, e.g. '!div'.
      */
     val operatorName: String
+
+    /**
+     * The known bang operator this node uses, or null if [operatorName] is not a recognized bang operator.
+     */
+    val operator: TableGenBangOperator?
+        get() = TableGenBangOperator.fromOperatorName(operatorName)
 }
 
 interface TableGenBoolValueNodeEx : TableGenAtomicValue {

--- a/src/main/resources/messages/MyBundle.properties
+++ b/src/main/resources/messages/MyBundle.properties
@@ -14,6 +14,11 @@ tableGen.syntax.switch.missingDefault='!switch' requires a default value as its 
 tableGen.syntax.switch.misplacedDefault=Only the last '!switch' argument may be the default; expected ':' followed by a value
 tableGen.syntax.switch.missingCase='!switch' requires at least one 'case : value' pair
 
+tableGen.syntax.unknownBangOperator=Unknown bang operator ''{0}''
+tableGen.syntax.bangOperator.argCount.exactly=Bang operator ''{0}'' expects exactly {1,choice,1#1 argument|1<{1} arguments}, but got {2}
+tableGen.syntax.bangOperator.argCount.atLeast=Bang operator ''{0}'' expects at least {1} arguments, but got {2}
+tableGen.syntax.bangOperator.argCount.range=Bang operator ''{0}'' expects {1} to {2} arguments, but got {3}
+
 tableGen.syntax.positionalAfterNamed=Positional argument is not allowed after a named argument
 
 tableGen.syntax.duplicateArgument=Template argument ''{0}'' is assigned more than once

--- a/src/test/kotlin/com/github/zero9178/mlirods/TableGenSyntaxAnnotatorTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/TableGenSyntaxAnnotatorTest.kt
@@ -84,6 +84,96 @@ class TableGenSyntaxAnnotatorTest : BasePlatformTestCase() {
         myFixture.checkHighlighting()
     }
 
+    fun `test known bang operator`() {
+        myFixture.configureByText(
+            "test.td", """
+            defvar v = !add(1, 2);
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test unknown bang operator`() {
+        myFixture.configureByText(
+            "test.td", """
+            defvar v = <error descr="Unknown bang operator '!bogus'">!bogus</error>(1, 2);
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test fixed arity operator with correct count`() {
+        myFixture.configureByText(
+            "test.td", """
+            defvar v = !div(6, 2);
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test fixed arity operator with too few arguments`() {
+        myFixture.configureByText(
+            "test.td", """
+            defvar v = <error descr="Bang operator '!div' expects exactly 2 arguments, but got 1">!div(6)</error>;
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test fixed arity operator with too many arguments`() {
+        myFixture.configureByText(
+            "test.td", """
+            defvar v = <error descr="Bang operator '!div' expects exactly 2 arguments, but got 3">!div(6, 2, 1)</error>;
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test unary operator reports singular argument`() {
+        myFixture.configureByText(
+            "test.td", """
+            defvar v = <error descr="Bang operator '!not' expects exactly 1 argument, but got 0">!not()</error>;
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test variadic operator with many arguments`() {
+        myFixture.configureByText(
+            "test.td", """
+            defvar v = !add(1, 2, 3, 4);
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test variadic operator with too few arguments`() {
+        myFixture.configureByText(
+            "test.td", """
+            defvar v = <error descr="Bang operator '!add' expects at least 2 arguments, but got 1">!add(1)</error>;
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test optional arity operator within range`() {
+        myFixture.configureByText(
+            "test.td", """
+            defvar v = !substr("hello", 1, 3);
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test optional arity operator out of range`() {
+        myFixture.configureByText(
+            "test.td", """
+            defvar v = <error descr="Bang operator '!substr' expects 2 to 3 arguments, but got 1">!substr("hello")</error>;
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
     fun `test positional only arguments`() {
         myFixture.configureByText(
             "test.td", """


### PR DESCRIPTION
The syntax annotator now reports an error for an unknown bang operator and for a known operator given the wrong number of arguments.