### PR TITLE
[TableGen] Fix serialization of class statement `hasBody` flag

### DIFF
--- a/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/impl/TableGenClassStatementStub.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/impl/TableGenClassStatementStub.kt
@@ -26,7 +26,7 @@ class TableGenClassStatementStubElementType(debugName: String) :
         ::TableGenClassStatementImpl
     ) {
 
-    override fun shouldCreateStub(node: ASTNode?): Boolean {
+    override fun shouldCreateStub(node: ASTNode): Boolean {
         return TableGenClassStatementImpl(node).identifier != null
     }
 
@@ -42,7 +42,7 @@ class TableGenClassStatementStubElementType(debugName: String) :
         stub: TableGenClassStatementStub, dataStream: StubOutputStream
     ) {
         dataStream.writeUTFFast(stub.name)
-        dataStream.writeBoolean(true)
+        dataStream.writeBoolean(stub.hasBody)
         dataStream.writeVarInt(stub.baseClassNames.size)
         stub.baseClassNames.forEach {
             dataStream.writeName(it)


### PR DESCRIPTION
`TableGenClassStatementStubElementType.serialize` always wrote `true` for the `hasBody` flag instead of the stub's actual `hasBody` value. As a result, every class statement restored from the stub index reported `hasBody == true`, regardless of whether the class actually had a body.

Write `stub.hasBody` so the flag round-trips correctly through serialize/deserialize.