### PR TITLE
[TableGen] Cache constant evaluation results per context

### DIFF
--- a/src/main/kotlin/com/github/zero9178/mlirods/language/TableGen.bnf
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/TableGen.bnf
@@ -633,7 +633,7 @@ field_access_value_node ::= value_node field_access_value_node_suffix {
         field_identifier="IDENTIFIER"
 
         getReference
-        evaluate
+        evaluateInner
     ]
     pin=2
     elementTypeClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenFieldAccessValueNodeStubElementType"
@@ -686,7 +686,6 @@ integer_value_node ::= '-'? INTEGER {
         "com.github.zero9178.mlirods.language.psi.impl.TableGenIntegerValueNodeEx"
     ]
     methods=[
-        evaluate
         evaluateAtomic
         toString
     ]
@@ -700,7 +699,6 @@ string_value_node ::= block_string_value
         "com.github.zero9178.mlirods.language.psi.impl.TableGenStringValueNodeEx"
     ]
     methods=[
-        evaluate
         evaluateAtomic
         toString
     ]
@@ -721,7 +719,6 @@ bool_value_node ::= 'true' | 'false' {
         "com.github.zero9178.mlirods.language.psi.impl.TableGenBoolValueNodeEx"
     ]
     methods=[
-        evaluate
         evaluateAtomic
         toString
     ]
@@ -733,7 +730,6 @@ undef_value_node ::= '?' {
         "com.github.zero9178.mlirods.language.psi.impl.TableGenAtomicValue"
     ]
     methods=[
-        evaluate
         evaluateAtomic
     ]
     elementTypeClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenUndefValueNodeStubElementType"
@@ -761,7 +757,7 @@ dag_arg ::= value_node (':' VAR_IDENTIFIER)? | VAR_IDENTIFIER {
 }
 identifier_value_node ::= IDENTIFIER {
     methods=[
-        evaluate
+        evaluateInner
         getReference
         toString
     ]

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenPsiImplUtil.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenPsiImplUtil.kt
@@ -288,10 +288,6 @@ class TableGenPsiImplUtil {
         fun toType(element: TableGenClassTypeNode) = TableGenRecordType.create(element)
 
         @JvmStatic
-        fun evaluate(element: TableGenAtomicValue, context: TableGenEvaluationContext): TableGenValue =
-            element.evaluateAtomic() ?: TableGenUnknownValue
-
-        @JvmStatic
         fun evaluateAtomic(element: TableGenIntegerValueNode): TableGenIntegerValue? {
             element.stub?.let {
                 return it.value?.let { value -> TableGenIntegerValue(value) }
@@ -302,7 +298,7 @@ class TableGenPsiImplUtil {
         }
 
         @JvmStatic
-        fun evaluate(element: TableGenIdentifierValueNode, context: TableGenEvaluationContext): TableGenValue {
+        fun evaluateInner(element: TableGenIdentifierValueNode, context: TableGenEvaluationContext): TableGenValue {
             return when (val ref = element.reference?.resolve()) {
                 is TableGenDefvarStatement -> ref.valueNode?.evaluate(context)
                 is TableGenDefStatement -> TableGenRecordValue(ref)
@@ -313,7 +309,7 @@ class TableGenPsiImplUtil {
         }
 
         @JvmStatic
-        fun evaluate(element: TableGenFieldAccessValueNode, context: TableGenEvaluationContext): TableGenValue {
+        fun evaluateInner(element: TableGenFieldAccessValueNode, context: TableGenEvaluationContext): TableGenValue {
             val record = element.valueNode.evaluate(context) as? TableGenRecordValue ?: return TableGenUnknownValue
             val fieldName = element.fieldName ?: return TableGenUnknownValue
             return record.fields[fieldName]

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenValueNodeEx.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenValueNodeEx.kt
@@ -12,17 +12,28 @@ import com.github.zero9178.mlirods.language.values.TableGenStringValue
 import com.github.zero9178.mlirods.language.values.TableGenUnknownValue
 import com.github.zero9178.mlirods.language.values.TableGenValue
 import com.intellij.psi.PsiElement
+import com.intellij.psi.util.CachedValuesManager
+import com.intellij.util.containers.ConcurrentFactoryMap
 
 /**
  * Class passed around as context during a constant evaluation.
  * This is used to keep track of things such as template parameter to argument mapping or field mappings.
+ *
+ * Two contexts are considered equal if they originate from the same [source]. This allows evaluation results
+ * to be cached per context (see [TableGenValueNodeEx.evaluate]).
  */
 class TableGenEvaluationContext private constructor(
+    private val source: Any?,
     val evaluateTemplateArgDeclInContext: TableGenEvaluationContext.(TableGenTemplateArgDecl) -> TableGenValue,
     val evaluateFieldInContext: TableGenEvaluationContext.(String) -> TableGenValue,
 ) {
 
+    /**
+     * Null-context. Template arguments and implicit field definitions yield unknown values.
+     * This is the context that should be used for top-level evaluation and class-statements.
+     */
     constructor() : this(
+        null,
         {
             TableGenUnknownValue
         },
@@ -31,7 +42,7 @@ class TableGenEvaluationContext private constructor(
         },
     )
 
-    constructor(defStatement: TableGenDefStatement) : this({
+    constructor(defStatement: TableGenDefStatement) : this(defStatement, {
         defStatement.allArgToTemplateArgMapping[it]?.evaluate(this) ?: TableGenUnknownValue
     }, { fieldName ->
         defStatement.allFieldAssignments[fieldName]?.lastOrNull()?.let {
@@ -44,6 +55,11 @@ class TableGenEvaluationContext private constructor(
             }
         }?.evaluate(this) ?: TableGenUnknownValue
     })
+
+    override fun equals(other: Any?): Boolean =
+        this === other || (other is TableGenEvaluationContext && source == other.source)
+
+    override fun hashCode(): Int = source.hashCode()
 }
 
 interface TableGenValueNodeEx : PsiElement {
@@ -60,8 +76,22 @@ interface TableGenValueNodeEx : PsiElement {
 
     /**
      * Performs constant evaluation of this value within the given context.
+     *
+     * Results are cached per [context] and invalidated on any PSI modification. Implementations should not override
+     * this method but [evaluateInner] instead.
      */
-    fun evaluate(context: TableGenEvaluationContext): TableGenValue = TableGenUnknownValue
+    fun evaluate(context: TableGenEvaluationContext): TableGenValue =
+        CachedValuesManager.getProjectPsiDependentCache(this) { element ->
+            ConcurrentFactoryMap.createMap<TableGenEvaluationContext, TableGenValue> {
+                element.evaluateInner(it)
+            }
+        }[context] ?: TableGenUnknownValue
+
+    /**
+     * Performs the actual constant evaluation of this value within the given context. Implemented per value node kind;
+     * callers should use [evaluate] which adds caching on top.
+     */
+    fun evaluateInner(context: TableGenEvaluationContext): TableGenValue = TableGenUnknownValue
 }
 
 /**
@@ -70,6 +100,15 @@ interface TableGenValueNodeEx : PsiElement {
  */
 interface TableGenAtomicValue : TableGenValueNodeEx {
     fun evaluateAtomic(): TableGenValue?
+
+    /**
+     * Atomic values do not depend on the [context] and are cheap to compute from their PSI subtree, so [evaluate]
+     * bypasses caching and resolves directly to [evaluateAtomic].
+     */
+    override fun evaluate(context: TableGenEvaluationContext): TableGenValue =
+        evaluateAtomic() ?: TableGenUnknownValue
+
+    override fun evaluateInner(context: TableGenEvaluationContext) = evaluate(context)
 }
 
 interface TableGenIntegerValueNodeEx : TableGenAtomicValue {


### PR DESCRIPTION
Constant evaluation of a value node was recomputed from scratch on every call. Since the same nodes are evaluated repeatedly during resolution and other features, this is wasteful and scales poorly on larger files.

Evaluation results now depend only on the node and the evaluation context, so they can be memoized: the result is cached per context and invalidated whenever the PSI changes. Atomic values are context- independent and cheap, so they are left uncached.

This keeps the caching concern in one place: value nodes express their actual evaluation logic, and the shared layer decides what to cache and when to invalidate it.