### PR TITLE
[TableGen] Diagnose constant division-by-zero through def instantiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 - Added errors for unknown bang operators and for bang operators given the wrong number of arguments
+- Added an error for a `!div` whose divisor evaluates to a constant zero, including when the zero only becomes apparent through a `def`'s instantiation of a class
 - Added support for the `!sort` operator
 - Added support for the `!filter` operator, including reference resolution and type inference of its iteration variable
 - Added support for the `!switch` operator, including validation of its case clauses and mandatory default value

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/annotator/TableGenConstantEvaluationAnnotator.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/annotator/TableGenConstantEvaluationAnnotator.kt
@@ -1,0 +1,135 @@
+package com.github.zero9178.mlirods.language.annotator
+
+import com.github.zero9178.mlirods.MyBundle
+import com.github.zero9178.mlirods.language.generated.psi.TableGenBangOperatorValueNode
+import com.github.zero9178.mlirods.language.generated.psi.TableGenDefStatement
+import com.github.zero9178.mlirods.language.generated.psi.TableGenValueNode
+import com.github.zero9178.mlirods.language.psi.TableGenBangOperator
+import com.github.zero9178.mlirods.language.psi.impl.TableGenAbstractLetItem
+import com.github.zero9178.mlirods.language.values.TableGenIntegerValue
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.psi.PsiElement
+import com.intellij.util.takeWhileInclusive
+
+/**
+ * Flags a `!div` whose divisor evaluates to the constant `0` within [holder]'s context. Mirroring TableGen, this only
+ * fires once both operands fold to concrete integers; a divisor that depends on a (still unknown) template argument
+ * does not fold and is therefore not reported.
+ */
+private fun checkDivisionByZero(element: TableGenBangOperatorValueNode, holder: TableGenEvaluationHolder) {
+    if (element.operator != TableGenBangOperator.DIV) return
+
+    // A well-formed '!div' has exactly two operands; a wrong operand count is reported by the syntax annotator.
+    val operands = element.valueNodeList
+    if (operands.size != 2) return
+
+    val dividend = operands[0].evaluate(holder.context)
+    val divisor = operands[1].evaluate(holder.context)
+    if (dividend !is TableGenIntegerValue || divisor !is TableGenIntegerValue) return
+    if (divisor.value != 0L) return
+
+    holder.error(operands[1], MyBundle.message("tableGen.syntax.divisionByZero"))
+}
+
+/**
+ * Checks that work by constant-evaluating value nodes.
+ */
+private val EVALUATION_CHECKS = arrayOf(
+    evaluationCheckFor { element: TableGenBangOperatorValueNode, holder -> checkDivisionByZero(element, holder) },
+)
+
+/**
+ * Returns the children of [element] that are evaluated in [holder]'s context.
+ * Specifically elements that are not evaluated due to conditional execution will not be part of the sequence.
+ */
+private fun liveChildrenOf(element: PsiElement, holder: TableGenEvaluationHolder): Sequence<PsiElement> {
+    if (element is TableGenBangOperatorValueNode && element.operator == TableGenBangOperator.IF) {
+        // Operands are '[condition, then, else]'. The condition is always evaluated.
+        val operands = element.valueNodeList
+        if (operands.size == 3) {
+            val branch =
+                when ((operands[0].evaluate(holder.context) as? TableGenIntegerValue)?.let { it.value != 0L }) {
+                    true -> operands[1]
+                    false -> operands[2]
+                    null -> null // Unknown condition: descend into neither branch.
+                }
+            return sequenceOf(operands[0], branch).filterNotNull()
+        }
+    }
+
+    return generateSequence(element.firstChild) { it.nextSibling }
+}
+
+/**
+ * Yields [root] and its descendant value nodes, evaluated in [holder]'s context, in post-order (a node after its
+ * children).
+ */
+private fun liveValuesPostOrder(
+    root: TableGenValueNode, holder: TableGenEvaluationHolder
+): Sequence<TableGenValueNode> = sequence {
+    val stack = mutableListOf<Pair<PsiElement, Iterator<PsiElement>>>()
+    stack.add(root to liveChildrenOf(root, holder).iterator())
+    while (stack.isNotEmpty()) {
+        val (node, children) = stack.last()
+        if (children.hasNext()) {
+            val child = children.next()
+            stack.add(child to liveChildrenOf(child, holder).iterator())
+        } else {
+            stack.removeLast()
+            if (node is TableGenValueNode) yield(node)
+        }
+    }
+}
+
+/**
+ * Runs the [EVALUATION_CHECKS] over [root] and its live descendant value nodes, evaluated in [holder]'s context.
+ */
+private fun visitLiveValues(root: TableGenValueNode, holder: TableGenEvaluationHolder) {
+    liveValuesPostOrder(root, holder).forEach { element ->
+        EVALUATION_CHECKS.forEach { check ->
+            // Only report a problem here if it does not already fail in the null context. Such constant problems are
+            // reported by the direct pass, so reporting them again for every instantiation would duplicate the annotation.
+            val probe = TableGenProbeEvaluationHolder()
+            check(element, probe)
+            if (!probe.emittedError) check(element, holder)
+        }
+    }
+}
+
+/**
+ * Re-runs the [EVALUATION_CHECKS] over every final field expression of [def], evaluated in the def's instantiation
+ * context. This catches problems that only become visible once a class's template arguments and fields are bound to
+ * concrete values, e.g. a `!div` whose divisor is a template argument that this def sets to `0`.
+ */
+private fun checkInstantiation(def: TableGenDefStatement, holder: AnnotationHolder) {
+    val anchor = def.nameIdentifier ?: return
+    val evaluationHolder = TableGenInstantiationEvaluationHolder(def, anchor, holder)
+    def.allFieldAssignments.values.asSequence().flatMap { assignments ->
+        // Include previous field assignments if the 'let' is in prepend or append mode.
+        assignments.asReversed().asSequence().takeWhileInclusive {
+            when (it) {
+                is TableGenAbstractLetItem -> it.letMode != null
+                else -> false
+            }
+        }
+    }.mapNotNull { it.assignedValueNode }.forEach {
+        visitLiveValues(it, evaluationHolder)
+    }
+}
+
+private val ANNOTATIONS = arrayOf(
+    // Run the evaluation-based checks directly on each value node, evaluated in the null context. A problem found here
+    // is constant (e.g. '!div(6, 0)') and therefore wrong as written, so it is reported even inside a dead '!if' branch.
+    addAnnotationFor { element: TableGenValueNode, holder: AnnotationHolder ->
+        val evaluationHolder = TableGenDirectEvaluationHolder(holder)
+        EVALUATION_CHECKS.forEach { it(element, evaluationHolder) }
+    },
+    // Re-run them on every def, this time through the def's instantiation context.
+    addAnnotationFor { element: TableGenDefStatement, holder -> checkInstantiation(element, holder) },
+)
+
+/**
+ * Annotator reporting problems found by constant-evaluating value nodes, both as written and as seen through each def's
+ * instantiation of a class.
+ */
+internal class TableGenConstantEvaluationAnnotator : TableGenAnnotator(ANNOTATIONS.asIterable())

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/annotator/TableGenEvaluationHolder.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/annotator/TableGenEvaluationHolder.kt
@@ -1,0 +1,96 @@
+package com.github.zero9178.mlirods.language.annotator
+
+import com.github.zero9178.mlirods.language.generated.psi.TableGenDefStatement
+import com.github.zero9178.mlirods.language.generated.psi.TableGenValueNode
+import com.github.zero9178.mlirods.language.psi.impl.TableGenEvaluationContext
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.Annotator
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.psi.PsiElement
+
+/**
+ * Abstraction over [AnnotationHolder] for checks that operate by constant-evaluating value nodes.
+ *
+ * The same check (e.g. division-by-zero) needs to run in two different situations:
+ *  - From a regular [Annotator], directly on a value node as written. Evaluation happens in the
+ *    [null context][TableGenEvaluationContext] and a problem is shown on the offending element itself.
+ *  - From the def-statement annotator, which re-evaluates a record's field expressions through the lens of a concrete
+ *    instantiation. Evaluation happens in that def's [context][TableGenEvaluationContext] and a problem is shown on the
+ *    def being highlighted, since the offending expression typically lives in a (possibly out-of-file) base class.
+ *
+ * Implementations decide which [context] to evaluate in and where (or whether) a reported problem ends up as an
+ * annotation. A check therefore only has to express *what* is wrong, not *how* it should be surfaced.
+ */
+interface TableGenEvaluationHolder {
+    /**
+     * Context in which checks should evaluate value nodes.
+     */
+    val context: TableGenEvaluationContext
+
+    /**
+     * Reports an error with the given [message]. [element] is the offending value node; implementations may use it to
+     * position the annotation and/or to decide whether the problem is relevant.
+     */
+    fun error(element: PsiElement, message: String)
+}
+
+/**
+ * A check that inspects a [TableGenValueNode] and reports problems via [TableGenEvaluationHolder].
+ */
+typealias TableGenEvaluationCheck = (element: TableGenValueNode, holder: TableGenEvaluationHolder) -> Unit
+
+/**
+ * Creates a [TableGenEvaluationCheck] that runs [check] whenever a value node of type [T] is encountered.
+ */
+inline fun <reified T : TableGenValueNode> evaluationCheckFor(crossinline check: (T, TableGenEvaluationHolder) -> Unit): TableGenEvaluationCheck =
+    { element, holder ->
+        if (element is T) check(element, holder)
+    }
+
+/**
+ * [TableGenEvaluationHolder] used by a regular [Annotator]: evaluates in the null context and surfaces problems
+ * directly on the offending element.
+ */
+internal class TableGenDirectEvaluationHolder(private val holder: AnnotationHolder) : TableGenEvaluationHolder {
+    override val context = TableGenEvaluationContext()
+
+    override fun error(element: PsiElement, message: String) {
+        holder.newAnnotation(HighlightSeverity.ERROR, message).range(element).create()
+    }
+}
+
+/**
+ * [TableGenEvaluationHolder] used when checking a [def][TableGenDefStatement] instantiation: evaluates field
+ * expressions in the def's context and anchors any problem on [anchor], a location inside the def being highlighted
+ * (the offending expression itself may live in an out-of-file base class).
+ */
+internal class TableGenInstantiationEvaluationHolder(
+    def: TableGenDefStatement,
+    private val anchor: PsiElement,
+    private val holder: AnnotationHolder,
+) : TableGenEvaluationHolder {
+    override val context = TableGenEvaluationContext(def)
+
+    override fun error(element: PsiElement, message: String) {
+        holder.newAnnotation(HighlightSeverity.ERROR, message).range(anchor).create()
+    }
+}
+
+/**
+ * [TableGenEvaluationHolder] that emits no annotations and merely records whether a check reported a problem, evaluating
+ * in the null context.
+ *
+ * It is used to find out whether a check already fails without any instantiation, i.e. whether the problem is constant
+ * and therefore already reported by [TableGenDirectEvaluationHolder]. Running it before re-checking in an instantiation
+ * context lets the instantiation pass skip such problems instead of reporting them a second time.
+ */
+internal class TableGenProbeEvaluationHolder : TableGenEvaluationHolder {
+    override val context = TableGenEvaluationContext()
+
+    var emittedError = false
+        private set
+
+    override fun error(element: PsiElement, message: String) {
+        emittedError = true
+    }
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenFieldAssignmentNode.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenFieldAssignmentNode.kt
@@ -1,0 +1,14 @@
+package com.github.zero9178.mlirods.language.psi
+
+import com.github.zero9178.mlirods.language.generated.psi.TableGenValueNode
+
+/**
+ * A [TableGenFieldIdentifierNode] that assigns a value to a field, as opposed to merely referencing one. Examples are a
+ * field body item (`int x = 5;`) or a `let` item (`let x = 5`).
+ */
+interface TableGenFieldAssignmentNode : TableGenFieldIdentifierNode {
+    /**
+     * Returns the value node assigned to the field, or null if it has none (e.g. due to an error in the AST).
+     */
+    val assignedValueNode: TableGenValueNode?
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenFieldScopeNode.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenFieldScopeNode.kt
@@ -61,7 +61,7 @@ interface TableGenFieldScopeNode : TableGenIdentifierScopeNode {
      * Returns a map of all field assignments in order of application (earliest to latest) that directly occur within
      * 'this'.
      */
-    val directFieldAssignments: Map<String, List<TableGenFieldIdentifierNode>>
+    val directFieldAssignments: Map<String, List<TableGenFieldAssignmentNode>>
 
     /**
      * Returns a sequence of all fields of this class, including inherited fields.
@@ -88,7 +88,7 @@ interface TableGenFieldScopeNode : TableGenIdentifierScopeNode {
      * transitive base classes.
      * The first element in a list is therefore always a field body item if valid TableGen.
      */
-    val allFieldAssignments: Map<String, List<TableGenFieldIdentifierNode>>
+    val allFieldAssignments: Map<String, List<TableGenFieldAssignmentNode>>
         get() = CachedValuesManager.getProjectPsiDependentCache(this) {
             val result = directFieldAssignments.toMutableMap()
             baseClassRefs.toList().asReversed().mapNotNull { it.referencedClass }.map {

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenAbstractLetItem.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenAbstractLetItem.kt
@@ -1,7 +1,8 @@
 package com.github.zero9178.mlirods.language.psi.impl
 
 import com.github.zero9178.mlirods.language.generated.TableGenTypes
-import com.github.zero9178.mlirods.language.psi.TableGenFieldIdentifierNode
+import com.github.zero9178.mlirods.language.generated.psi.TableGenValueNode
+import com.github.zero9178.mlirods.language.psi.TableGenFieldAssignmentNode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.elementType
 
@@ -9,7 +10,14 @@ enum class LetMode {
     Prepend, Append,
 }
 
-interface TableGenAbstractLetItem : PsiElement, TableGenFieldIdentifierNode {
+interface TableGenAbstractLetItem : PsiElement, TableGenFieldAssignmentNode {
+    /**
+     * Returns the value node assigned by this let item.
+     */
+    val valueNode: TableGenValueNode?
+
+    override val assignedValueNode: TableGenValueNode?
+        get() = valueNode
     /**
      * Returns the identifier representing the 'let'-mode if present.
      * Note that it does not verify whether the identifier is one of "prepend" or "append".

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenFieldBodyItemEx.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenFieldBodyItemEx.kt
@@ -1,8 +1,9 @@
 package com.github.zero9178.mlirods.language.psi.impl
 
 import com.github.zero9178.mlirods.language.generated.psi.TableGenFieldBodyItem
+import com.github.zero9178.mlirods.language.psi.TableGenFieldAssignmentNode
 
-interface TableGenFieldBodyItemEx {
+interface TableGenFieldBodyItemEx : TableGenFieldAssignmentNode {
 
     /**
      * Returns the defining [TableGenFieldBodyItem] of this field.

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenFieldBodyItemMixin.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenFieldBodyItemMixin.kt
@@ -35,6 +35,8 @@ abstract class TableGenFieldBodyItemMixin : StubBasedPsiElementBase<TableGenFiel
     override val fieldName: String?
         get() = name
 
+    override val assignedValueNode get() = valueNode
+
     override fun getTextOffset(): Int {
         return nameIdentifier?.textOffset ?: super.getTextOffset()
     }

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenRecordStatementMixin.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenRecordStatementMixin.kt
@@ -4,7 +4,7 @@ import com.github.zero9178.mlirods.language.generated.psi.TableGenClassRef
 import com.github.zero9178.mlirods.language.generated.psi.TableGenDefvarStatement
 import com.github.zero9178.mlirods.language.generated.psi.TableGenFieldBodyItem
 import com.github.zero9178.mlirods.language.generated.psi.TableGenLetBodyItem
-import com.github.zero9178.mlirods.language.psi.TableGenFieldIdentifierNode
+import com.github.zero9178.mlirods.language.psi.TableGenFieldAssignmentNode
 import com.github.zero9178.mlirods.language.psi.TableGenFieldScopeNode
 import com.github.zero9178.mlirods.language.psi.TableGenIdentifierElement
 import com.github.zero9178.mlirods.language.psi.TableGenIdentifierScopeNode.IdMapEntry
@@ -57,7 +57,7 @@ abstract class TableGenRecordStatementMixin<StubT : StubElement<*>> : StubBasedP
     override val directFields by myDirectFields
 
     private var myDirectFieldAssignments = resettableLazy {
-        stubbedChildren<TableGenFieldIdentifierNode>(
+        stubbedChildren<TableGenFieldAssignmentNode>(
             TableGenFieldBodyItem::class.java,
             TableGenLetBodyItem::class.java
         ).mapNotNull {

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenValueNodeEx.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenValueNodeEx.kt
@@ -45,15 +45,9 @@ class TableGenEvaluationContext private constructor(
     constructor(defStatement: TableGenDefStatement) : this(defStatement, {
         defStatement.allArgToTemplateArgMapping[it]?.evaluate(this) ?: TableGenUnknownValue
     }, { fieldName ->
-        defStatement.allFieldAssignments[fieldName]?.lastOrNull()?.let {
-            when (it) {
-                is TableGenFieldBodyItem -> it.valueNode
-                // TODO: Implement append and prepend semantics.
-                is TableGenLetBodyItem -> it.valueNode
-                is TableGenLetItem -> it.valueNode
-                else -> null
-            }
-        }?.evaluate(this) ?: TableGenUnknownValue
+        // TODO: Implement append and prepend semantics.
+        defStatement.allFieldAssignments[fieldName]?.lastOrNull()?.assignedValueNode
+            ?.evaluate(this) ?: TableGenUnknownValue
     })
 
     override fun equals(other: Any?): Boolean =

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -105,6 +105,9 @@
         <annotator language="TableGen"
                    implementationClass="com.github.zero9178.mlirods.language.annotator.TableGenSemanticAnnotator"
         />
+        <annotator language="TableGen"
+                   implementationClass="com.github.zero9178.mlirods.language.annotator.TableGenConstantEvaluationAnnotator"
+        />
         <localInspection language="TableGen"
                          shortName="TableGenRedefinedField"
                          bundle="messages.MyBundle"

--- a/src/main/resources/messages/MyBundle.properties
+++ b/src/main/resources/messages/MyBundle.properties
@@ -26,6 +26,8 @@ tableGen.syntax.unknownNamedArgument=Class ''{0}'' has no template argument name
 tableGen.syntax.tooManyArguments=Too many arguments for class ''{0}''; expected at most {1}
 tableGen.syntax.missingArgument=Missing value for required template argument ''{0}''
 
+tableGen.syntax.divisionByZero=Division by zero
+
 tableGen.inspection.group=TableGen
 tableGen.inspection.redefinedField.displayName=Field redefinition
 tableGen.inspection.redefinedField.message=Redefinition of existing field ''{0}:{1}''

--- a/src/test/kotlin/com/github/zero9178/mlirods/TableGenSyntaxAnnotatorTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/TableGenSyntaxAnnotatorTest.kt
@@ -111,6 +111,122 @@ class TableGenSyntaxAnnotatorTest : BasePlatformTestCase() {
         myFixture.checkHighlighting()
     }
 
+    fun `test division by zero`() {
+        myFixture.configureByText(
+            "test.td", """
+            defvar v = !div(6, <error descr="Division by zero">0</error>);
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test division by non-integer divisor is not flagged`() {
+        myFixture.configureByText(
+            "test.td", """
+            defvar v = !div(6, "x");
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test division by zero through a defvar`() {
+        doResolvingTest(
+            """
+            defvar z = 0;
+            defvar v = !div(6, <error descr="Division by zero">z</error>);
+        """.trimIndent()
+        )
+    }
+
+    fun `test division by an unknown template argument is not flagged`() {
+        doResolvingTest(
+            """
+            class C<int x> { int v = !div(6, x); }
+        """.trimIndent()
+        )
+    }
+
+    fun `test division by zero revealed through a def instantiation`() {
+        doResolvingTest(
+            """
+            class C<int x> { int v = !div(6, x); }
+            def <error descr="Division by zero">D</error> : C<0>;
+        """.trimIndent()
+        )
+    }
+
+    fun `test division by a non-zero template argument is not flagged`() {
+        doResolvingTest(
+            """
+            class C<int x> { int v = !div(6, x); }
+            def D : C<2>;
+        """.trimIndent()
+        )
+    }
+
+    fun `test division by zero through an overridden field is revealed on instantiation`() {
+        doResolvingTest(
+            """
+            class C { int x = 1; int v = !div(6, x); }
+            def <error descr="Division by zero">D</error> : C { let x = 0; }
+        """.trimIndent()
+        )
+    }
+
+    fun `test division by zero literal inside a def is reported once`() {
+        doResolvingTest(
+            """
+            def D { int v = !div(6, <error descr="Division by zero">0</error>); }
+        """.trimIndent()
+        )
+    }
+
+    fun `test constant division by zero is flagged even in a dead if branch`() {
+        myFixture.configureByText(
+            "test.td", """
+            defvar v = !if(1, 0, !div(6, <error descr="Division by zero">0</error>));
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test division by zero in a live if branch is flagged`() {
+        myFixture.configureByText(
+            "test.td", """
+            defvar v = !if(1, !div(6, <error descr="Division by zero">0</error>), 0);
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test division by zero in a live if branch is revealed on instantiation`() {
+        doResolvingTest(
+            """
+            class C<int x> { int v = !if(1, !div(6, x), 99); }
+            def <error descr="Division by zero">D</error> : C<0>;
+        """.trimIndent()
+        )
+    }
+
+    fun `test division by zero in a dead if branch is not flagged on instantiation`() {
+        doResolvingTest(
+            """
+            class C<int x> { int v = !if(0, !div(6, x), 99); }
+            def D : C<0>;
+        """.trimIndent()
+        )
+    }
+
+    fun `test division by zero nested in a class instantiation argument is revealed on instantiation`() {
+        doResolvingTest(
+            """
+            class Inner<int y>;
+            class C<int x> { Inner v = Inner<!div(6, x)>; }
+            def <error descr="Division by zero">D</error> : C<0>;
+        """.trimIndent()
+        )
+    }
+
     fun `test fixed arity operator with too few arguments`() {
         myFixture.configureByText(
             "test.td", """


### PR DESCRIPTION
A `!div` by zero is wrong as written, but a divisor can also fold to zero only once a def binds a class's template arguments and fields. Run the constant-evaluation checks both directly and through each def's instantiation context so the latter case is caught too, while skipping dead `!if` branches the instantiation never evaluates to avoid false positives.