### PR TITLE
[TableGen] Store let-mode on the let-body-item stub

### DIFF
--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenLetBodyItemMixin.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenLetBodyItemMixin.kt
@@ -30,6 +30,13 @@ abstract class TableGenLetBodyItemMixin : StubBasedPsiElementBase<TableGenLetBod
     override val fieldName: String?
         get() = name
 
+    override val letMode: LetMode?
+        get() {
+            greenStub?.let { return it.letMode }
+
+            return super.letMode
+        }
+
     override fun getTextOffset(): Int {
         return fieldIdentifier?.textOffset ?: super.getTextOffset()
     }

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/TableGenStubFileElementType.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/TableGenStubFileElementType.kt
@@ -29,7 +29,7 @@ class TableGenStubFileElementType :
     }
 
     override fun getStubVersion(): Int {
-        return 19
+        return 20
     }
 
     override fun deserialize(

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/impl/TableGenLetBodyItemStub.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/impl/TableGenLetBodyItemStub.kt
@@ -3,6 +3,7 @@ package com.github.zero9178.mlirods.language.stubs.impl
 
 import com.github.zero9178.mlirods.language.generated.psi.TableGenLetBodyItem
 import com.github.zero9178.mlirods.language.generated.psi.impl.TableGenLetBodyItemImpl
+import com.github.zero9178.mlirods.language.psi.impl.LetMode
 import com.github.zero9178.mlirods.language.stubs.TableGenStubElementType
 import com.github.zero9178.mlirods.language.stubs.TableGenStubElementTypes
 import com.intellij.psi.PsiElement
@@ -16,6 +17,11 @@ import com.intellij.psi.stubs.StubOutputStream
  */
 interface TableGenLetBodyItemStub : StubElement<TableGenLetBodyItem> {
     val name: String?
+
+    /**
+     * The 'prepend' or 'append' mode of the let, or null if it has none.
+     */
+    val letMode: LetMode?
 }
 
 class TableGenLetBodyItemStubElementType(debugName: String) :
@@ -24,24 +30,28 @@ class TableGenLetBodyItemStubElementType(debugName: String) :
     override fun createStub(
         psi: TableGenLetBodyItem, parentStub: StubElement<out PsiElement?>?
     ): TableGenLetBodyItemStub {
-        return TableGenLetBodyItemStubImpl(psi.fieldName, parentStub)
+        return TableGenLetBodyItemStubImpl(psi.fieldName, psi.letMode, parentStub)
     }
 
     override fun serialize(
         stub: TableGenLetBodyItemStub, dataStream: StubOutputStream
     ) {
         dataStream.writeName(stub.name)
+        dataStream.writeBoolean(stub.letMode != null)
+        stub.letMode?.let { dataStream.writeByte(it.ordinal) }
     }
 
     override fun deserialize(
         dataStream: StubInputStream, parentStub: StubElement<*>?
     ): TableGenLetBodyItemStub {
-        return TableGenLetBodyItemStubImpl(dataStream.readNameString(), parentStub)
+        val name = dataStream.readNameString()
+        val letMode = if (dataStream.readBoolean()) LetMode.entries[dataStream.readByte().toInt()] else null
+        return TableGenLetBodyItemStubImpl(name, letMode, parentStub)
     }
 }
 
 private class TableGenLetBodyItemStubImpl(
-    override val name: String?, parent: StubElement<out PsiElement>?
+    override val name: String?, override val letMode: LetMode?, parent: StubElement<out PsiElement>?
 ) : StubBase<TableGenLetBodyItem>(
     parent, TableGenStubElementTypes.LET_BODY_ITEM
 ), TableGenLetBodyItemStub


### PR DESCRIPTION
Field-assignment traversal reaches let items through the stub tree, so reading a let's prepend/append mode no longer needs to fall back to the AST. Serialize the mode onto the stub and read it from there when available.