### PR TITLE
[Model] Only reparse files whose preprocessor outcome actually changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Improved performance when compile commands or include paths change: a file is now only reparsed and reindexed when a macro it actually tests via `#ifdef`/`#ifndef` changes its defined state, rather than on every context update.
+
 ## [0.14.0] - 2026-06-25
 
 ### Added

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/TableGen.bnf
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/TableGen.bnf
@@ -189,13 +189,21 @@ preprocessor_directive ::= define_directive
 skipped_code_block ::=
 
 define_directive ::= '#define' IDENTIFIER {
-    extends=preprocessor_directive
     pin=1
+    methods=[toString]
+    implements=["com.github.zero9178.mlirods.language.psi.impl.TableGenMacroDirectiveEx"]
+    stubClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenMacroDirectiveStub"
+    mixin="com.github.zero9178.mlirods.language.psi.impl.TableGenMacroDirectiveMixin"
+    elementTypeClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenDefineDirectiveStubElementType"
 }
 
 ifdef_ifndef_directive ::= ('#ifdef' | '#ifndef') IDENTIFIER {
-    extends=preprocessor_directive
     pin=1
+    methods=[toString]
+    implements=["com.github.zero9178.mlirods.language.psi.impl.TableGenMacroDirectiveEx"]
+    stubClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenMacroDirectiveStub"
+    mixin="com.github.zero9178.mlirods.language.psi.impl.TableGenMacroDirectiveMixin"
+    elementTypeClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenIfdefIfndefDirectiveStubElementType"
 }
 
 else_directive ::= '#else' {

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/TableGenParserDefinition.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/TableGenParserDefinition.kt
@@ -4,12 +4,9 @@ import com.github.zero9178.mlirods.language.generated.TableGenParser
 import com.github.zero9178.mlirods.language.generated.TableGenTypes
 import com.github.zero9178.mlirods.language.psi.TableGenFile
 import com.github.zero9178.mlirods.language.stubs.TableGenStubFileElementType
-import com.github.zero9178.mlirods.model.TableGenContext
-import com.github.zero9178.mlirods.model.TableGenContextService
 import com.intellij.lang.ASTNode
 import com.intellij.lang.ParserDefinition
 import com.intellij.lexer.Lexer
-import com.intellij.openapi.components.serviceOrNull
 import com.intellij.openapi.project.Project
 import com.intellij.psi.FileViewProvider
 import com.intellij.psi.PsiElement
@@ -30,9 +27,6 @@ internal class TableGenParserDefinition : ParserDefinition {
     override fun createElement(node: ASTNode?): PsiElement = TableGenTypes.Factory.createElement(node)
 
     override fun createFile(viewProvider: FileViewProvider) = TableGenFile(
-        viewProvider,
-        // Note: [serviceOrNull] is needed for parser tests which do not have any services.
-        viewProvider.manager.project.serviceOrNull<TableGenContextService>()
-            ?.getActiveContext(viewProvider.virtualFile) ?: TableGenContext(),
+        viewProvider
     )
 }

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenFile.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenFile.kt
@@ -7,7 +7,9 @@ import com.github.zero9178.mlirods.language.generated.psi.TableGenClassStatement
 import com.github.zero9178.mlirods.language.generated.psi.TableGenIncludeDirective
 import com.github.zero9178.mlirods.language.stubs.TableGenStubElementTypes
 import com.github.zero9178.mlirods.model.TableGenContext
+import com.github.zero9178.mlirods.model.TableGenContextService
 import com.intellij.extapi.psi.PsiFileBase
+import com.intellij.openapi.components.serviceOrNull
 import com.intellij.openapi.fileTypes.FileType
 import com.intellij.psi.FileViewProvider
 import com.intellij.psi.PsiElement
@@ -16,8 +18,14 @@ import com.intellij.psi.tree.TokenSet
 import com.intellij.util.ArrayFactory
 import com.intellij.util.resettableLazy
 
-class TableGenFile(viewProvider: FileViewProvider, val context: TableGenContext) :
-    PsiFileBase(viewProvider, TableGenLanguage.INSTANCE), TableGenIdentifierScopeNode {
+class TableGenFile(viewProvider: FileViewProvider) : PsiFileBase(viewProvider, TableGenLanguage.INSTANCE),
+    TableGenIdentifierScopeNode {
+
+    val context: TableGenContext
+        get() = originalFile.virtualFile?.let {
+            // Note: [serviceOrNull] is needed for parser tests which do not have any services.
+            project.serviceOrNull<TableGenContextService>()?.getActiveContext(it)
+        } ?: TableGenContext()
 
     override fun getFileType(): FileType = TableGenFileType.INSTANCE
 
@@ -33,11 +41,15 @@ class TableGenFile(viewProvider: FileViewProvider, val context: TableGenContext)
         }.filterIsInstance<T>()
     }
 
+    private val myIncludeDirectives = resettableLazy {
+        stubStream(TableGenStubElementTypes.INCLUDE_DIRECTIVE).toList()
+    }
+
     /**
-     * Returns a sequence of all include directives in the file.
+     * Returns all include directives in the file.
      */
     val includeDirectives: Sequence<TableGenIncludeDirective>
-        get() = stubStream(TableGenStubElementTypes.INCLUDE_DIRECTIVE)
+        get() = myIncludeDirectives.value.asSequence()
 
     private val myClassMap = resettableLazy {
         val result = mutableMapOf<String, MutableList<TableGenClassStatement>>()
@@ -66,22 +78,33 @@ class TableGenFile(viewProvider: FileViewProvider, val context: TableGenContext)
             it::getChildrenAsPsiElements
         }(TokenSet.create(TableGenTypes.DEF_STATEMENT, TableGenTypes.DEFVAR_STATEMENT)) {
             arrayOfNulls<TableGenIdentifierElement>(it)
+        }.mapNotNull {
+            val name = it.name ?: return@mapNotNull null
+            name to it
+        }.groupBy({
+            it.first
+        }) {
+            TableGenIdentifierScopeNode.IdMapEntry(it.second)
         }
-            .mapNotNull {
-                val name = it.name ?: return@mapNotNull null
-                name to it
-            }.groupBy({
-                it.first
-            }) {
-                TableGenIdentifierScopeNode.IdMapEntry(it.second)
-            }
     }
 
     override val directIdMap by myDirectIdMap
 
-    override fun subtreeChanged() {
-        super.subtreeChanged()
+    private val myUsedMacros = resettableLazy {
+        stubStream(TableGenStubElementTypes.IFDEF_IFNDEF_DIRECTIVE).mapNotNullTo(mutableSetOf()) { it.macroName }
+    }
+
+    /**
+     * Returns the set of macro names tested by '#ifdef'/'#ifndef' directives in the file, i.e. the macros whose
+     * defined-state this file's parse result depends on.
+     */
+    val usedMacros: Set<String> by myUsedMacros
+
+    override fun clearCaches() {
+        super.clearCaches()
+        myIncludeDirectives.reset()
         myClassMap.reset()
         myDirectIdMap.reset()
+        myUsedMacros.reset()
     }
 }

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenMacroDirectiveEx.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenMacroDirectiveEx.kt
@@ -1,0 +1,15 @@
+package com.github.zero9178.mlirods.language.psi.impl
+
+import com.intellij.psi.PsiElement
+
+/**
+ * Interface used to add extra methods to the preprocessor directives carrying a macro name, i.e.
+ * [com.github.zero9178.mlirods.language.generated.psi.TableGenDefineDirective] and
+ * [com.github.zero9178.mlirods.language.generated.psi.TableGenIfdefIfndefDirective].
+ */
+interface TableGenMacroDirectiveEx : PsiElement {
+    /**
+     * Name of the macro defined ('#define') or tested ('#ifdef'/'#ifndef') by this directive.
+     */
+    val macroName: String?
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenMacroDirectiveMixin.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenMacroDirectiveMixin.kt
@@ -1,0 +1,22 @@
+package com.github.zero9178.mlirods.language.psi.impl
+
+import com.github.zero9178.mlirods.language.generated.TableGenTypes
+import com.github.zero9178.mlirods.language.stubs.impl.TableGenMacroDirectiveStub
+import com.intellij.extapi.psi.StubBasedPsiElementBase
+import com.intellij.lang.ASTNode
+import com.intellij.psi.stubs.IStubElementType
+
+/**
+ * Mixin shared by the preprocessor directives carrying a macro name ('#define', '#ifdef' and '#ifndef').
+ * The macro name is stored on the stub so that it can be queried without reparsing the file.
+ */
+abstract class TableGenMacroDirectiveMixin : StubBasedPsiElementBase<TableGenMacroDirectiveStub>,
+    TableGenMacroDirectiveEx {
+
+    override val macroName: String?
+        get() = greenStub?.macroName ?: node.findChildByType(TableGenTypes.IDENTIFIER)?.text
+
+    constructor(node: ASTNode) : super(node)
+
+    constructor(stub: TableGenMacroDirectiveStub, stubType: IStubElementType<*, *>) : super(stub, stubType)
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/TableGenStubElementTypes.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/TableGenStubElementTypes.kt
@@ -11,6 +11,12 @@ interface TableGenStubElementTypes {
         val INCLUDE_DIRECTIVE = TableGenTypes.INCLUDE_DIRECTIVE!!
 
         @JvmField
+        val DEFINE_DIRECTIVE = TableGenTypes.DEFINE_DIRECTIVE!!
+
+        @JvmField
+        val IFDEF_IFNDEF_DIRECTIVE = TableGenTypes.IFDEF_IFNDEF_DIRECTIVE!!
+
+        @JvmField
         val DEFVAR_STATEMENT = TableGenTypes.DEFVAR_STATEMENT!!
 
         @JvmField

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/TableGenStubFileElementType.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/TableGenStubFileElementType.kt
@@ -29,7 +29,7 @@ class TableGenStubFileElementType :
     }
 
     override fun getStubVersion(): Int {
-        return 20
+        return 21
     }
 
     override fun deserialize(

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/impl/TableGenMacroDirectiveStub.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/impl/TableGenMacroDirectiveStub.kt
@@ -1,0 +1,54 @@
+package com.github.zero9178.mlirods.language.stubs.impl
+
+import com.github.zero9178.mlirods.language.generated.psi.impl.TableGenDefineDirectiveImpl
+import com.github.zero9178.mlirods.language.generated.psi.impl.TableGenIfdefIfndefDirectiveImpl
+import com.github.zero9178.mlirods.language.psi.impl.TableGenMacroDirectiveEx
+import com.github.zero9178.mlirods.language.stubs.TableGenStubElementType
+import com.intellij.psi.PsiElement
+import com.intellij.psi.stubs.*
+
+/**
+ * Stub interface for the preprocessor directives carrying a macro name ('#define', '#ifdef' and '#ifndef').
+ */
+sealed interface TableGenMacroDirectiveStub : StubElement<TableGenMacroDirectiveEx> {
+    /**
+     * Name of the macro defined or tested by the directive.
+     */
+    val macroName: String?
+}
+
+abstract class TableGenAbstractMacroDirectiveStubElementType(
+    debugName: String,
+    constructor: (TableGenMacroDirectiveStub, IStubElementType<*, *>) -> TableGenMacroDirectiveEx
+) : TableGenStubElementType<TableGenMacroDirectiveStub, TableGenMacroDirectiveEx>(debugName, constructor) {
+
+    override fun createStub(
+        psi: TableGenMacroDirectiveEx, parentStub: StubElement<out PsiElement?>?
+    ): TableGenMacroDirectiveStub = TableGenMacroDirectiveStubImpl(psi.macroName, parentStub, this)
+
+    override fun serialize(
+        stub: TableGenMacroDirectiveStub, dataStream: StubOutputStream
+    ) {
+        dataStream.writeName(stub.macroName)
+    }
+
+    override fun deserialize(
+        dataStream: StubInputStream, parentStub: StubElement<*>?
+    ): TableGenMacroDirectiveStub = TableGenMacroDirectiveStubImpl(dataStream.readNameString(), parentStub, this)
+
+    override fun isAlwaysLeaf(root: StubBase<*>) = true
+}
+
+private class TableGenMacroDirectiveStubImpl(
+    override val macroName: String?,
+    parent: StubElement<out PsiElement>?,
+    elementType: TableGenAbstractMacroDirectiveStubElementType,
+) : StubBase<TableGenMacroDirectiveEx>(parent, elementType), TableGenMacroDirectiveStub
+
+class TableGenDefineDirectiveStubElementType(debugName: String) : TableGenAbstractMacroDirectiveStubElementType(
+    debugName, ::TableGenDefineDirectiveImpl
+)
+
+class TableGenIfdefIfndefDirectiveStubElementType(debugName: String) : TableGenAbstractMacroDirectiveStubElementType(
+    debugName, ::TableGenIfdefIfndefDirectiveImpl
+)

--- a/src/main/kotlin/com/github/zero9178/mlirods/model/CompilationCommands.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/model/CompilationCommands.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -54,7 +55,7 @@ class CompilationCommands(private val project: Project, private val cs: Coroutin
         val newFlow = EP_NAME.computeSafeIfAny {
             it.getCompilationCommandsFlow(project)
         } ?: return
-        myBackingFlowEmission = cs.launch {
+        myBackingFlowEmission = cs.launch(start = CoroutineStart.UNDISPATCHED) {
             newFlow.collect {
                 myStateFlow.value = it
             }

--- a/src/main/kotlin/com/github/zero9178/mlirods/model/TableGenContext.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/model/TableGenContext.kt
@@ -248,17 +248,17 @@ class TableGenContextService(val project: Project, private val cs: CoroutineScop
                 val instance = PsiManager.getInstance(project)
                 val fileManager = fileManager.await()
                 readAndBackgroundWriteAction {
-                    if (!file.isValid) return@readAndBackgroundWriteAction ReadResult.value(Unit)
+                    if (!file.isValid) return@readAndBackgroundWriteAction value(Unit)
 
                     val tableGenFile = (instance.findFile(file) as? TableGenFile)
-                        ?: return@readAndBackgroundWriteAction ReadResult.value(
+                        ?: return@readAndBackgroundWriteAction value(
                             Unit
                         )
                     val needsReparse = tableGenFile.usedMacros.any {
                         oldDefines.contains(it) != newDefines.contains(it)
                     }
-                    if (!needsReparse) ReadResult.value(Unit)
-                    else ReadResult.writeAction {
+                    if (!needsReparse) value(Unit)
+                    else writeAction {
                         fileManager.setViewProvider(file, null)
                         FileBasedIndex.getInstance().requestReindex(file)
                     }

--- a/src/main/kotlin/com/github/zero9178/mlirods/model/TableGenContext.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/model/TableGenContext.kt
@@ -4,23 +4,22 @@ import com.github.zero9178.mlirods.MyBundle
 import com.github.zero9178.mlirods.language.TableGenFileType
 import com.github.zero9178.mlirods.language.psi.TableGenFile
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ReadResult
 import com.intellij.openapi.application.readAction
-import com.intellij.openapi.application.writeAction
+import com.intellij.openapi.application.readAndBackgroundWriteAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.fileTypes.FileType
-import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.checkCanceled
-import com.intellij.openapi.progress.runBlockingCancellable
-import com.intellij.openapi.project.DumbModeTask
-import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.ModificationTracker
 import com.intellij.openapi.util.SimpleModificationTracker
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.originalFileOrSelf
+import com.intellij.platform.ide.progress.withBackgroundProgress
+import com.intellij.platform.util.progress.reportProgressScope
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import com.intellij.psi.PsiTreeAnyChangeAbstractAdapter
@@ -31,21 +30,13 @@ import com.intellij.psi.util.CachedValuesManager
 import com.intellij.util.concurrency.annotations.RequiresReadLock
 import com.intellij.util.indexing.FileBasedIndex
 import com.jetbrains.rd.util.firstOrNull
-import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.PersistentMap
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.persistentMapOf
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.updateAndGet
-import kotlinx.coroutines.launch
+import kotlinx.collections.immutable.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
+import org.jetbrains.annotations.TestOnly
 import java.io.Closeable
-import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks.ReentrantReadWriteLock
+import java.util.concurrent.locks.StampedLock
 import kotlin.concurrent.read
 import kotlin.concurrent.write
 
@@ -69,7 +60,7 @@ data class TableGenContext(
      * These can and should be treated identically to as if they were include statements at the beginning of the file
      * this context belongs to.
      */
-    val includedBeforeThis: Set<VirtualFile> = emptySet()
+    val includedBeforeThis: PersistentSet<VirtualFile> = persistentSetOf()
 )
 
 /**
@@ -90,132 +81,21 @@ class TableGenContextService(val project: Project, private val cs: CoroutineScop
      * Modification tracker which gets incremented each time an 'include' directive may resolve to a new file.
      */
     val includeResultModificationTracker: ModificationTracker
-        get() = contextChangedModificationTracker
+        field = SimpleModificationTracker()
 
     /**
      * Modification tracker which gets incremented each time a context changes.
+     * Note that it is a super-set of [includeResultModificationTracker].
      */
     val contextChangedModificationTracker: ModificationTracker
         field = SimpleModificationTracker()
 
-    private inner class Contexts(val file: VirtualFile) : Closeable {
-        /**
-         * Updates the contained contexts using [function] and performs a [refresh] iff the context changed.
-         * Suspends until the fresh is complete.
-         */
-        suspend fun updateAndRefresh(
-            function: (PersistentMap<VirtualFile, TableGenContext>) -> PersistentMap<VirtualFile, TableGenContext>
-        ) {
-            var refresh = true
-            synchronized(this) {
-                val newContexts = function(myContexts)
-                if (newContexts == myContexts) {
-                    return
-                }
-                if (newContexts.firstOrNull() == myContexts.firstOrNull()) refresh = false
-
-                myContexts = newContexts
-            }
-            if (!refresh) return
-
-            val epoch = myWriteActionRequestedFlow.updateAndGet { it + 1 }
-            myWriteActionCompletedFlow.first { it >= epoch }
-        }
-
-        /**
-         * Refreshes all effects this file has on included files and propagates a new context to them if needed.
-         * Suspends until all context changes that this refresh caused have finished.
-         */
-        suspend fun refresh() {
-            val epoch = myRefreshRequestedFlow.updateAndGet { it + 1 }
-            myRefreshCompletedFlow.first { it >= epoch }
-        }
-
-        override fun close() = myJob.cancel()
-
-        val contextToUse: TableGenContext?
-            get() = synchronized(this) {
-                myContexts.firstOrNull()?.value
-            }
-
-        private val myRefreshCompletedFlow = MutableStateFlow(0L)
-        private val myRefreshRequestedFlow = MutableStateFlow(0L)
-        private val myWriteActionCompletedFlow = MutableStateFlow(0L)
-        private val myWriteActionRequestedFlow = MutableStateFlow(0L)
-
-        private val myJob = cs.launch {
-            try {
-                coroutineScope {
-                    launch {
-                        myRefreshRequestedFlow.collectLatest { epoch ->
-                            if (epoch <= 0) return@collectLatest
-
-                            pushUpdatesToIncludesAfterNewContext(file)
-                            myRefreshCompletedFlow.emit(epoch)
-                        }
-                    }
-                    launch {
-                        myWriteActionRequestedFlow.collectLatest { epoch ->
-                            if (epoch <= 0) return@collectLatest
-
-                            val fileManager = fileManager.await()
-                            // Invalidate the Psi such that the 'TableGenFile' instance gets reallocated.
-                            writeAction {
-                                // Write actions before may have made the file invalid.
-                                if (!file.isValid) return@writeAction
-
-                                fileManager.setViewProvider(file, null)
-                            }
-
-                            readAction {
-                                // Write actions before may have made the file invalid.
-                                if (!file.isValid) return@readAction
-
-                                // Massive workaround for stale indices.
-                                // IntelliJ technically only allows file content dependent Psis and indices created
-                                // from that Psi. However, TableGen is not context dependent due to the preprocessor
-                                // and includes. We keep the index up to date by requesting reindexing when the context
-                                // changes.
-                                FileBasedIndex.getInstance().requestReindex(file)
-                            }
-
-                            // Propagate the new context further.
-                            contextChangedModificationTracker.incModificationCount()
-                            refresh()
-                            myWriteActionCompletedFlow.emit(epoch)
-                        }
-                    }
-                }
-            } finally {
-                // Unblock any coroutines waiting by now considering all requests completed from now on.
-                myRefreshCompletedFlow.value = Long.MAX_VALUE
-                myWriteActionCompletedFlow.value = Long.MAX_VALUE
-            }
-        }
-        private var myContexts = persistentMapOf<VirtualFile, TableGenContext>()
-    }
-
-    private val myFileToContexts: MutableMap<VirtualFile, Contexts> = mutableMapOf()
-    private val myLock = ReentrantReadWriteLock()
-    private val fileManager = cs.async {
-        (project.service<PsiManager>() as PsiManagerEx).fileManager
-    }
-
-    private suspend fun refreshAllFiles() = coroutineScope {
-        myLock.read {
-            myFileToContexts.values.toList()
-        }.forEach {
-            launch {
-                it.refresh()
-            }
-        }
-    }
-
-    private suspend fun refreshFile(file: VirtualFile) {
-        myLock.read {
-            myFileToContexts[file]
-        }?.refresh()
-    }
+    /**
+     * [SharedFlow] that receives the compilation commands state any time that state has been finished applying.
+     */
+    @TestOnly
+    val finishedCompileCommands: SharedFlow<CompilationCommandsState>
+        field = MutableStateFlow(CompilationCommandsState())
 
     init {
         // Refresh the world if any TableGen file is added or removed as any include resolution might now change.
@@ -223,7 +103,7 @@ class TableGenContextService(val project: Project, private val cs: CoroutineScop
             FileTypeIndex.INDEX_CHANGE_TOPIC, object : FileTypeIndex.IndexChangeListener {
                 override fun onChangedForFileType(fileType: FileType) {
                     if (fileType != TableGenFileType.INSTANCE) return
-                    contextChangedModificationTracker.incModificationCount()
+                    includeResultModificationTracker.incModificationCount()
                     cs.launch {
                         val startTime = System.nanoTime()
                         refreshAllFiles()
@@ -246,60 +126,202 @@ class TableGenContextService(val project: Project, private val cs: CoroutineScop
             }
         }, this)
 
-        cs.launch {
+        cs.launch(start = CoroutineStart.UNDISPATCHED) {
             // Apply value changes to all files mentioned in the compile commands.
             project.service<CompilationCommands>().stateFlow.collectLatest { state ->
                 if (state == CompilationCommandsState()) return@collectLatest
 
-                DumbService.getInstance(project).queueTask(object : DumbModeTask() {
-                    override fun performInDumbMode(indicator: ProgressIndicator) {
-                        indicator.isIndeterminate = false
-                        indicator.text = MyBundle.message("tableGen.progress.updatingContexts")
-                        runBlockingCancellable {
-                            val startTime = System.nanoTime()
-                            // Drive the fraction off the compile-command entries, the bulk of the work. Modern
-                            // 'reportProgress' is not visible through 'runBlockingCancellable' under an indicator, so we
-                            // update the indicator directly.
-                            val total = state.map.size
-                            val completed = AtomicInteger()
-                            coroutineScope {
-                                val updated = mutableSetOf<VirtualFile>()
-                                state.map.forEach { (key, value) ->
-                                    launch {
-                                        getContextsForFile(key).updateAndRefresh {
-                                            persistentMapOf(
-                                                key to TableGenContext(includePaths = value.paths)
-                                            )
-                                        }
-                                        if (total > 0) indicator.fraction =
-                                            completed.incrementAndGet().toDouble() / total
-                                    }
-                                    updated.add(key)
-                                }
-
-                                // Erase all entries from previous compile commands.
-                                myLock.read {
-                                    myFileToContexts.toList()
-                                }.forEach { (key, value) ->
-                                    if (updated.contains(key)) return@forEach
-
-                                    launch {
-                                        // Roots use themselves as keys.
-                                        value.updateAndRefresh {
-                                            it.remove(key)
-                                        }
-                                    }
+                withBackgroundProgress(project, MyBundle.message("tableGen.progress.updatingContexts")) {
+                    val startTime = System.nanoTime()
+                    // Drive the fraction off the compile-command entries, the bulk of the work.
+                    // 'withBackgroundProgress' installs a reporter into the coroutine context, which
+                    // 'runBlockingCancellable' inherits, so 'reportProgressScope' is visible here.
+                    reportProgressScope(state.map.size) { reporter ->
+                        val updated = mutableSetOf<VirtualFile>()
+                        state.map.forEach { (key, value) ->
+                            launch(start = CoroutineStart.UNDISPATCHED) {
+                                reporter.itemStep(MyBundle.message("tableGen.progress.updatingContext", key.name)) {
+                                    getContextsForFile(key).updateAndRefresh(this) {
+                                        persistentMapOf(
+                                            key to TableGenContext(includePaths = value.paths)
+                                        )
+                                    }?.join()
                                 }
                             }
-                            val endTime = System.nanoTime()
-                            LOGGER.info(
-                                "Updating contexts after compile commands change took ${(endTime - startTime) / 1.0e9} seconds"
-                            )
+                            updated.add(key)
+                        }
+
+                        // Erase all entries from previous compile commands.
+                        myLock.read {
+                            myFileToContexts.toList()
+                        }.forEach { (key, value) ->
+                            if (updated.contains(key)) return@forEach
+
+                            // Roots use themselves as keys.
+                            value.updateAndRefresh(this) {
+                                it.remove(key)
+                            }
                         }
                     }
-                })
+                    val endTime = System.nanoTime()
+                    LOGGER.info(
+                        "Updating contexts after compile commands change took ${(endTime - startTime) / 1.0e9} seconds"
+                    )
+                }
+                finishedCompileCommands.emit(state)
             }
         }
+    }
+
+    private suspend fun refreshAllFiles() = coroutineScope {
+        myLock.read {
+            myFileToContexts.values.toList()
+        }.forEach {
+            launch {
+                it.refresh()
+            }
+        }
+    }
+
+    private suspend fun refreshFile(file: VirtualFile) {
+        myLock.read {
+            myFileToContexts[file]
+        }?.refresh()
+    }
+
+    private inner class Contexts(val file: VirtualFile) : Closeable {
+        /**
+         * Updates the contained contexts using [function] and performs a [refresh] iff the context changed.
+         * The refresh is performed as a separate job launched within [cs] that is returned by this method.
+         */
+        fun updateAndRefresh(
+            cs: CoroutineScope,
+            function: (PersistentMap<VirtualFile, TableGenContext>) -> PersistentMap<VirtualFile, TableGenContext>
+        ): Job? {
+            // Start out holding only a read lock to compute the new contexts and upgrade to a write lock lazily, as the
+            // common case is that no mutation is required.
+            var stamp = myLock.readLock()
+            val (oldContext, newContext) = try {
+                var newContexts = function(myContexts)
+                // Nothing changed; the read lock was all we ever needed.
+                if (newContexts == myContexts) {
+                    return null
+                }
+
+                // A mutation is required, so upgrade to a write lock. The upgrade may fail under contention, in which
+                // case we drop the read lock, acquire the write lock outright and recompute against the now up-to-date
+                // contexts.
+                val writeStamp = myLock.tryConvertToWriteLock(stamp)
+                if (writeStamp != 0L) {
+                    stamp = writeStamp
+                } else {
+                    myLock.unlockRead(stamp)
+                    stamp = myLock.writeLock()
+                    newContexts = function(myContexts)
+                    if (newContexts == myContexts) {
+                        return null
+                    }
+                }
+
+                if (newContexts.firstOrNull() == myContexts.firstOrNull()) {
+                    // TODO: Refresh currently only takes the active context into account meaning no refresh is needed
+                    //       if the active context doesn't change.
+                    contextChangedModificationTracker.incModificationCount()
+                    myContexts = newContexts
+                    return null
+                }
+
+                val old = myContexts
+                myContexts = newContexts
+                old to newContexts
+            } finally {
+                myLock.unlock(stamp)
+            }
+            contextChangedModificationTracker.incModificationCount()
+            if (newContext.firstOrNull()?.value?.includePaths != oldContext.firstOrNull()?.value?.includePaths) {
+                includeResultModificationTracker.incModificationCount()
+            }
+
+            return cs.launch {
+                val oldDefines = oldContext.firstOrNull()?.value?.defines.orEmpty()
+                val newDefines = newContext.firstOrNull()?.value?.defines.orEmpty()
+                val instance = PsiManager.getInstance(project)
+                val fileManager = fileManager.await()
+                readAndBackgroundWriteAction {
+                    if (!file.isValid) return@readAndBackgroundWriteAction ReadResult.value(Unit)
+
+                    val tableGenFile = (instance.findFile(file) as? TableGenFile)
+                        ?: return@readAndBackgroundWriteAction ReadResult.value(
+                            Unit
+                        )
+                    val needsReparse = tableGenFile.usedMacros.any {
+                        oldDefines.contains(it) != newDefines.contains(it)
+                    }
+                    if (!needsReparse) ReadResult.value(Unit)
+                    else ReadResult.writeAction {
+                        fileManager.setViewProvider(file, null)
+                        FileBasedIndex.getInstance().requestReindex(file)
+                    }
+                }
+
+                refresh()
+            }
+        }
+
+        /**
+         * Refreshes all effects this file has on included files and propagates a new context to them if needed.
+         * Suspends until all context changes that this refresh caused have finished.
+         */
+        suspend fun refresh() {
+            val epoch = myRefreshRequestedFlow.updateAndGet { it + 1 }
+            myRefreshCompletedFlow.first { it >= epoch }
+        }
+
+        override fun close() = myJob.cancel()
+
+        /**
+         * Returns the active context of [file] that is used for include paths, defines and more.
+         */
+        val contextToUse: TableGenContext?
+            get() {
+                // Reading a single reference; an optimistic read avoids blocking concurrent writers.
+                val stamp = myLock.tryOptimisticRead()
+                val contexts = myContexts
+                if (myLock.validate(stamp)) {
+                    return contexts.firstOrNull()?.value
+                }
+                val readStamp = myLock.readLock()
+                try {
+                    return myContexts.firstOrNull()?.value
+                } finally {
+                    myLock.unlockRead(readStamp)
+                }
+            }
+
+        private val myRefreshCompletedFlow = MutableStateFlow(0L)
+        private val myRefreshRequestedFlow = MutableStateFlow(0L)
+        private val myLock = StampedLock()
+
+        private val myJob = cs.launch(start = CoroutineStart.UNDISPATCHED) {
+            try {
+                myRefreshRequestedFlow.collect { epoch ->
+                    if (epoch <= 0) return@collect
+
+                    pushUpdatesToIncludesAfterNewContext(file)
+                    myRefreshCompletedFlow.emit(epoch)
+                }
+            } finally {
+                // Unblock any coroutines waiting by now considering all requests completed from now on.
+                myRefreshCompletedFlow.value = Long.MAX_VALUE
+            }
+        }
+        private var myContexts = persistentMapOf<VirtualFile, TableGenContext>()
+    }
+
+    private val myFileToContexts: MutableMap<VirtualFile, Contexts> = mutableMapOf()
+    private val myLock = ReentrantReadWriteLock()
+    private val fileManager = cs.async {
+        (project.service<PsiManager>() as PsiManagerEx).fileManager
     }
 
     private fun getContextsForFile(file: VirtualFile) = myLock.read {
@@ -339,7 +361,7 @@ class TableGenContextService(val project: Project, private val cs: CoroutineScop
         }
 
         val currentDefines = mutableSetOf<String>()
-        val includedSoFar = newContext.includedBeforeThis.toMutableSet()
+        var includedSoFar = newContext.includedBeforeThis
         included.forEach { file ->
             checkCanceled()
 
@@ -347,14 +369,12 @@ class TableGenContextService(val project: Project, private val cs: CoroutineScop
             if (file == updatedFile) return@forEach
 
             val context = TableGenContext(
-                newContext.includedFrom.add(updatedFile), newContext.includePaths, currentDefines, includedSoFar.toSet()
+                newContext.includedFrom.add(updatedFile), newContext.includePaths, currentDefines, includedSoFar
             )
-            launch {
-                getContextsForFile(file).updateAndRefresh { existing ->
-                    existing.put(updatedFile, context)
-                }
+            getContextsForFile(file).updateAndRefresh(this) { existing ->
+                existing.put(updatedFile, context)
             }
-            includedSoFar.add(file)
+            includedSoFar = includedSoFar.add(file)
         }
 
         // Remove old newContext from all files where it no longer applies.
@@ -364,16 +384,17 @@ class TableGenContextService(val project: Project, private val cs: CoroutineScop
                 if (includedSoFar.contains(key)) return@forEach
                 if (key == updatedFile) return@forEach
 
-                launch {
-                    value.updateAndRefresh {
-                        it.remove(updatedFile)
-                    }
+                value.updateAndRefresh(this) {
+                    it.remove(updatedFile)
                 }
             }
         }
     }
 
-    fun getActiveContext(virtualFile: VirtualFile) = myLock.read {
+    /**
+     * Returns the context that is used to parse [virtualFile] or an empty context if none exists.
+     */
+    fun getActiveContext(virtualFile: VirtualFile): TableGenContext = myLock.read {
         myFileToContexts[virtualFile.originalFileOrSelf()]?.contextToUse ?: TableGenContext()
     }
 

--- a/src/main/resources/messages/MyBundle.properties
+++ b/src/main/resources/messages/MyBundle.properties
@@ -9,6 +9,7 @@ tableGen.tools.displayName=TableGen
 tableGen.lsp.enable=Use tblgen-lsp-server for additional diagnostics
 
 tableGen.progress.updatingContexts=Updating TableGen contexts
+tableGen.progress.updatingContext=Updating context for ''{0}''
 
 tableGen.syntax.invalidLetMode=Expected one of ''append'' or ''prepend'' instead of ''{0}''
 

--- a/src/test/kotlin/com/github/zero9178/mlirods/ContextTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/ContextTest.kt
@@ -1,0 +1,182 @@
+package com.github.zero9178.mlirods
+
+import com.github.zero9178.mlirods.language.psi.TableGenFile
+import com.github.zero9178.mlirods.model.IncludePaths
+import com.github.zero9178.mlirods.model.TableGenContext
+import com.github.zero9178.mlirods.model.TableGenContextService
+import com.intellij.openapi.components.service
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiManager
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+/**
+ * Tests for [TableGenContextService] context propagation: how include paths from the compile commands flow into the
+ * root file and transitively into all (directly and indirectly) included files, and how [TableGenContext.includedFrom],
+ * [TableGenContext.includedBeforeThis] and [TableGenContextService.getIncludedFiles] are populated as a result.
+ */
+class ContextTest : BasePlatformTestCase() {
+
+    private fun tableGenFile(vf: VirtualFile): TableGenFile =
+        PsiManager.getInstance(project).findFile(vf) as TableGenFile
+
+    private fun contextOf(vf: VirtualFile): TableGenContext = tableGenFile(vf).context
+
+    private fun includedFiles(vf: VirtualFile): Set<VirtualFile> =
+        project.service<TableGenContextService>().getIncludedFiles(tableGenFile(vf))
+
+    fun `test compile command propagates include paths to root`() {
+        val root = myFixture.createFile("root.td", "")
+        val dir = root.parent
+        installCompileCommands(project, mapOf(root to IncludePaths(listOf(dir))))
+
+        val context = contextOf(root)
+        assertEquals(listOf(dir), context.includePaths)
+        // A root is not included from anywhere and nothing is included before it.
+        assertEmpty(context.includedFrom)
+        assertEmpty(context.includedBeforeThis)
+    }
+
+    fun `test direct include inherits includedFrom and include paths`() {
+        val included = myFixture.createFile("included.td", "")
+        val root = myFixture.createFile(
+            "root.td", """
+            include "included.td"
+        """.trimIndent()
+        )
+        val dir = root.parent
+        installCompileCommands(project, mapOf(root to IncludePaths(listOf(dir))))
+
+        val context = contextOf(included)
+        assertEquals(listOf(root), context.includedFrom.toList())
+        // Include paths propagate unchanged from the root.
+        assertEquals(listOf(dir), context.includePaths)
+    }
+
+    fun `test transitive include builds includedFrom chain`() {
+        val leaf = myFixture.createFile("leaf.td", "")
+        val mid = myFixture.createFile(
+            "mid.td", """
+            include "leaf.td"
+        """.trimIndent()
+        )
+        val root = myFixture.createFile(
+            "root.td", """
+            include "mid.td"
+        """.trimIndent()
+        )
+        val dir = root.parent
+        installCompileCommands(project, mapOf(root to IncludePaths(listOf(dir))))
+
+        // 'mid' is included directly from the root.
+        assertEquals(listOf(root), contextOf(mid).includedFrom.toList())
+        // 'leaf' is included from the root via 'mid'; the chain is ordered from outermost to innermost.
+        assertEquals(listOf(root, mid), contextOf(leaf).includedFrom.toList())
+        // Include paths propagate down the entire chain.
+        assertEquals(listOf(dir), contextOf(leaf).includePaths)
+    }
+
+    fun `test includedBeforeThis reflects earlier includes`() {
+        val first = myFixture.createFile("first.td", "")
+        val second = myFixture.createFile("second.td", "")
+        val root = myFixture.createFile(
+            "root.td", """
+            include "first.td"
+            include "second.td"
+        """.trimIndent()
+        )
+        val dir = root.parent
+        installCompileCommands(project, mapOf(root to IncludePaths(listOf(dir))))
+
+        // 'second' is preceded by 'first' in the root, so 'first' is visible to it.
+        assertContainsElements(contextOf(second).includedBeforeThis, first)
+        // 'first' has nothing before it.
+        assertEmpty(contextOf(first).includedBeforeThis)
+    }
+
+    fun `test getIncludedFiles returns transitive includes`() {
+        val leaf = myFixture.createFile("leaf.td", "")
+        val mid = myFixture.createFile(
+            "mid.td", """
+            include "leaf.td"
+        """.trimIndent()
+        )
+        val root = myFixture.createFile(
+            "root.td", """
+            include "mid.td"
+        """.trimIndent()
+        )
+        val dir = root.parent
+        installCompileCommands(project, mapOf(root to IncludePaths(listOf(dir))))
+
+        // The root transitively includes both 'mid' and 'leaf'.
+        assertContainsElements(includedFiles(root), mid, leaf)
+    }
+
+    fun `test getIncludedFiles contains the includedFrom chain`() {
+        val leaf = myFixture.createFile("leaf.td", "")
+        val mid = myFixture.createFile(
+            "mid.td", """
+            include "leaf.td"
+        """.trimIndent()
+        )
+        val root = myFixture.createFile(
+            "root.td", """
+            include "mid.td"
+        """.trimIndent()
+        )
+        val dir = root.parent
+        installCompileCommands(project, mapOf(root to IncludePaths(listOf(dir))))
+
+        // Definitions in the files we are included from are visible, so they are part of the included set.
+        assertContainsElements(includedFiles(leaf), root, mid)
+    }
+
+    fun `test recursive include is handled gracefully`() {
+        val a = myFixture.createFile(
+            "a.td", """
+            include "b.td"
+        """.trimIndent()
+        )
+        val b = myFixture.createFile(
+            "b.td", """
+            include "a.td"
+        """.trimIndent()
+        )
+        val dir = a.parent
+        // Must terminate despite the cycle.
+        installCompileCommands(project, mapOf(a to IncludePaths(listOf(dir))))
+
+        // Both files see each other, but the traversal does not loop forever.
+        assertContainsElements(includedFiles(a), b)
+        assertContainsElements(includedFiles(b), a)
+    }
+
+    fun `test updating compile commands switches active root`() {
+        val shared = myFixture.createFile("shared.td", "")
+        val rootA = myFixture.createFile(
+            "rootA.td", """
+            include "shared.td"
+        """.trimIndent()
+        )
+        val rootB = myFixture.createFile(
+            "rootB.td", """
+            include "shared.td"
+        """.trimIndent()
+        )
+        val dir = shared.parent
+
+        val update = compileCommandsUpdater(project)
+        update(mapOf(rootA to IncludePaths(listOf(dir))))
+        assertEquals(listOf(dir), contextOf(rootA).includePaths)
+        assertContainsElements(contextOf(shared).includedFrom, rootA)
+
+        // Replace the compile commands so only 'rootB' is a root anymore.
+        update(mapOf(rootB to IncludePaths(listOf(dir))))
+        // 'rootB' is now a root with the include paths.
+        assertEquals(listOf(dir), contextOf(rootB).includePaths)
+        // 'rootA' is no longer a root and its include paths have been cleared.
+        assertEmpty(contextOf(rootA).includePaths)
+        // 'shared' is still reachable from the now-active root.
+        assertContainsElements(includedFiles(rootB), shared)
+    }
+}

--- a/src/test/kotlin/com/github/zero9178/mlirods/ReferenceTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/ReferenceTest.kt
@@ -17,9 +17,6 @@ class ReferenceTest : BasePlatformTestCase() {
         installCompileCommands(
             project, mapOf(
                 virtualFile to IncludePaths(listOf(testFile.parent))
-            ),
-            listOf(
-                targetFile to IncludePaths(listOf(testFile.parent))
             )
         )
 
@@ -44,9 +41,6 @@ class ReferenceTest : BasePlatformTestCase() {
         installCompileCommands(
             project, mapOf(
                 root to IncludePaths(listOf(testFile.parent))
-            ),
-            listOf(
-                testFile to IncludePaths(listOf(testFile.parent))
             )
         )
 
@@ -99,9 +93,6 @@ class ReferenceTest : BasePlatformTestCase() {
         installCompileCommands(
             project, mapOf(
                 root to IncludePaths(listOf(testFile.parent))
-            ),
-            listOf(
-                testFile to IncludePaths(listOf(testFile.parent))
             )
         )
 

--- a/src/test/kotlin/com/github/zero9178/mlirods/RenameTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/RenameTest.kt
@@ -12,9 +12,6 @@ class RenameTest : BasePlatformTestCase() {
             project,
             mapOf(
                 virtualFile to IncludePaths(listOf(testFile.parent))
-            ),
-            listOf(
-                inputFile to IncludePaths(listOf(testFile.parent))
             )
         )
 

--- a/src/test/kotlin/com/github/zero9178/mlirods/TestUtil.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/TestUtil.kt
@@ -1,56 +1,57 @@
 package com.github.zero9178.mlirods
 
-import com.github.zero9178.mlirods.language.psi.TableGenFile
-import com.github.zero9178.mlirods.model.CompilationCommandsState
-import com.github.zero9178.mlirods.model.IncludePaths
-import com.github.zero9178.mlirods.model.TableGenCompilationCommandsProvider
-import com.github.zero9178.mlirods.model.getCompilationCommandsEP
+import com.github.zero9178.mlirods.model.*
+import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.psi.PsiManager
 import com.intellij.testFramework.ExtensionTestUtil
 import com.intellij.testFramework.IndexingTestUtil
-import com.intellij.testFramework.PlatformTestUtil
 import com.intellij.testFramework.UsefulTestCase
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 
 /**
  * Testing utility which installs the include paths given by [map] into [project].
  * Include-file-related functionality is guaranteed to work for any files given as keys of the map.
- * Additional files whose context should be resolved through propagation should be given in [additionalPropagation].
  */
 fun UsefulTestCase.installCompileCommands(
-    project: Project, map: Map<VirtualFile, IncludePaths>,
-    additionalPropagation: List<Pair<VirtualFile, IncludePaths>> = emptyList()
+    project: Project, map: Map<VirtualFile, IncludePaths>
 ) {
     assert(map.isNotEmpty())
+    compileCommandsUpdater(project)(map)
+}
 
+/**
+ * Installs a single mutable compile-commands provider into [project] and returns a function that applies a new
+ * [CompilationCommandsState] and waits for it to finish being applied.
+ *
+ * Unlike [installCompileCommands], this masks the extension point only once and can therefore be used to apply several
+ * states in sequence (the platform forbids re-masking an extension point).
+ */
+fun UsefulTestCase.compileCommandsUpdater(project: Project): (Map<VirtualFile, IncludePaths>) -> Unit {
+    val flow = MutableStateFlow(CompilationCommandsState())
     ExtensionTestUtil.maskExtensions(
         getCompilationCommandsEP(),
         listOf(object : TableGenCompilationCommandsProvider {
-            override fun getCompilationCommandsFlow(project: Project): Flow<CompilationCommandsState> {
-                return flowOf(
-                    CompilationCommandsState(
-                        map
-                    )
-                )
-            }
+            override fun getCompilationCommandsFlow(project: Project): Flow<CompilationCommandsState> = flow
         }),
         testRootDisposable,
         fireEvents = true
     )
 
-    val list = map.toList() + additionalPropagation
-    PlatformTestUtil.waitWhileBusy {
-        list.any {
-            val file =
-                PsiManager.getInstance(project).findFile(it.first) as? TableGenFile
-            if (file == null)
-                true
-            else file.context.includePaths != it.second.paths
+    return { map ->
+        val state = CompilationCommandsState(map)
+        runBlocking {
+            val job = launch(start = CoroutineStart.UNDISPATCHED) {
+                project.service<TableGenContextService>().finishedCompileCommands.first { it == state }
+            }
+            flow.value = state
+            job.join()
         }
+        IndexingTestUtil.waitUntilIndexesAreReady(project)
     }
-
-    IndexingTestUtil.waitUntilIndexesAreReady(project)
 }


### PR DESCRIPTION
When compile commands or include paths changed, every affected file was unconditionally reparsed and reindexed as the new context propagated through the include tree. This was the dominant cost of a context update even though most files' parse results are unaffected by the change.

A file's parse result can only differ if a macro it tests via '#ifdef'/'#ifndef' flips between defined and undefined. To check this cheaply, cache each file's include directives and tested macros on its TableGenFile stub, then reparse a file only when one of its tested macros actually changes its defined state for the new context.