### PR TITLE
[TableGen] Invalidate resolution and evaluation caches on context changes

### DIFF
--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenArgValueItemReference.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenArgValueItemReference.kt
@@ -5,10 +5,10 @@ import com.github.zero9178.mlirods.language.generated.psi.TableGenArgValueItem
 import com.github.zero9178.mlirods.language.psi.impl.TableGenEvaluationContext
 import com.github.zero9178.mlirods.language.stubs.disallowTreeLoading
 import com.github.zero9178.mlirods.language.values.TableGenStringValue
+import com.github.zero9178.mlirods.model.getProjectContextDependentCache
 import com.intellij.psi.PsiElementResolveResult
 import com.intellij.psi.PsiReferenceBase
 import com.intellij.psi.ResolveResult
-import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.util.parentOfType
 import com.intellij.util.concurrency.annotations.RequiresReadLock
 
@@ -26,7 +26,7 @@ class TableGenArgValueItemReference(element: TableGenArgValueItem) :
 
     @RequiresReadLock
     override fun multiResolve(incompleteCode: Boolean): Array<out ResolveResult> =
-        CachedValuesManager.getProjectPsiDependentCache(element) {
+        getProjectContextDependentCache(element) {
             disallowTreeLoading {
                 val classRef = element.parentOfType<TableGenAbstractClassRef>()
                     ?: return@disallowTreeLoading emptyArray<ResolveResult>()

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenClassReference.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenClassReference.kt
@@ -8,13 +8,13 @@ import com.github.zero9178.mlirods.language.generated.psi.TableGenClassStatement
 import com.github.zero9178.mlirods.language.generated.psi.TableGenScopeItem
 import com.github.zero9178.mlirods.language.stubs.disallowTreeLoading
 import com.github.zero9178.mlirods.model.TableGenIncludedSearchScope
+import com.github.zero9178.mlirods.model.getProjectContextDependentCache
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.IndexNotReadyException
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementResolveResult
 import com.intellij.psi.PsiReferenceBase
 import com.intellij.psi.ResolveResult
-import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.util.parentsOfType
 import com.intellij.util.concurrency.annotations.RequiresReadLock
 
@@ -63,7 +63,7 @@ class TableGenClassReference(element: TableGenAbstractClassRef) :
 
     @RequiresReadLock
     override fun multiResolve(incompleteCode: Boolean): Array<out ResolveResult> =
-        CachedValuesManager.getProjectPsiDependentCache(element) {
+        getProjectContextDependentCache(element) {
             disallowTreeLoading {
                 val name = element.className
                 val file = element.containingFile as? TableGenFile ?: return@disallowTreeLoading emptyArray()

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenFieldScopeNode.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenFieldScopeNode.kt
@@ -5,8 +5,8 @@ import com.github.zero9178.mlirods.language.generated.psi.TableGenFieldBodyItem
 import com.github.zero9178.mlirods.language.generated.psi.TableGenTemplateArgDecl
 import com.github.zero9178.mlirods.language.generated.psi.TableGenValueNode
 import com.github.zero9178.mlirods.language.stubs.disallowTreeLoading
+import com.github.zero9178.mlirods.model.getProjectContextDependentCache
 import com.intellij.psi.PsiElement
-import com.intellij.psi.util.CachedValuesManager
 
 /**
  * Map used to lookup fields within a [TableGenFieldScopeNode].
@@ -89,7 +89,7 @@ interface TableGenFieldScopeNode : TableGenIdentifierScopeNode {
      * The first element in a list is therefore always a field body item if valid TableGen.
      */
     val allFieldAssignments: Map<String, List<TableGenFieldAssignmentNode>>
-        get() = CachedValuesManager.getProjectPsiDependentCache(this) {
+        get() = getProjectContextDependentCache(this) {
             val result = directFieldAssignments.toMutableMap()
             baseClassRefs.toList().asReversed().mapNotNull { it.referencedClass }.map {
                 it.allFieldAssignments
@@ -109,7 +109,7 @@ interface TableGenFieldScopeNode : TableGenIdentifierScopeNode {
     val baseClassRefs: Sequence<TableGenClassRef>
 
     val directArgToTemplateArgMapping: Map<TableGenTemplateArgDecl, TableGenValueNode>
-        get() = CachedValuesManager.getProjectPsiDependentCache(this) {
+        get() = getProjectContextDependentCache(this) {
             baseClassRefs.flatMap { ref ->
                 ref.argValueItemList.flatMap {
                     val referencedTemplateArgDecl = it.referencedTemplateArgDecl ?: return@flatMap emptyList()
@@ -120,7 +120,7 @@ interface TableGenFieldScopeNode : TableGenIdentifierScopeNode {
         }
 
     val allArgToTemplateArgMapping: Map<TableGenTemplateArgDecl, TableGenValueNode>
-        get() = CachedValuesManager.getProjectPsiDependentCache(this) {
+        get() = getProjectContextDependentCache(this) {
             val result = directArgToTemplateArgMapping.toMutableMap()
             baseClassRefs.mapNotNull { it.referencedClass?.allArgToTemplateArgMapping }.forEach {
                 it.forEach { (decl, node) ->

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenIdentifierReference.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenIdentifierReference.kt
@@ -5,13 +5,13 @@ import com.github.zero9178.mlirods.index.getElements
 import com.github.zero9178.mlirods.language.completion.createLookupElement
 import com.github.zero9178.mlirods.language.generated.psi.TableGenIdentifierValueNode
 import com.github.zero9178.mlirods.model.TableGenIncludedSearchScope
+import com.github.zero9178.mlirods.model.getProjectContextDependentCache
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.IndexNotReadyException
 import com.intellij.psi.PsiElementResolveResult
 import com.intellij.psi.PsiReferenceBase
 import com.intellij.psi.ResolveResult
 import com.intellij.psi.search.GlobalSearchScope
-import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.util.isAncestor
 import com.intellij.util.concurrency.annotations.RequiresReadLock
 
@@ -63,7 +63,7 @@ class TableGenIdentifierReference(element: TableGenIdentifierValueNode) :
 
     @RequiresReadLock
     override fun multiResolve(incompleteCode: Boolean): Array<out ResolveResult> =
-        CachedValuesManager.getProjectPsiDependentCache(element) { element ->
+        getProjectContextDependentCache(element) { element ->
             val name = element.identifier.text
 
             val def = TableGenIdentifierScopeNode.getParentScope(element)?.let {
@@ -71,7 +71,7 @@ class TableGenIdentifierReference(element: TableGenIdentifierValueNode) :
             }
 
             // Lookup in the same file succeeded.
-            if (def != null) return@getProjectPsiDependentCache arrayOf(PsiElementResolveResult(def))
+            if (def != null) return@getProjectContextDependentCache arrayOf(PsiElementResolveResult(def))
             val project = element.project
             if (DumbService.isDumb(project)) throw IndexNotReadyException.create()
 

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenClassStatementEx.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenClassStatementEx.kt
@@ -4,11 +4,11 @@ import com.github.zero9178.mlirods.index.MAY_DERIVE_CLASS_INDEX
 import com.github.zero9178.mlirods.index.getElements
 import com.github.zero9178.mlirods.language.generated.psi.TableGenClassStatement
 import com.github.zero9178.mlirods.language.psi.TableGenRecord
+import com.github.zero9178.mlirods.model.getProjectContextDependentCache
 import com.intellij.navigation.NavigationItem
 import com.intellij.openapi.util.RecursionManager
 import com.intellij.psi.PsiNameIdentifierOwner
 import com.intellij.psi.search.GlobalSearchScope
-import com.intellij.psi.util.CachedValuesManager
 
 interface TableGenClassStatementEx : PsiNameIdentifierOwner, NavigationItem, TableGenRecord {
     /**
@@ -29,9 +29,9 @@ interface TableGenClassStatementEx : PsiNameIdentifierOwner, NavigationItem, Tab
      * Note that this currently doesn't include inline class instantiation values.
      */
     val directivelyDerivedRecords: Sequence<TableGenRecord>
-        get() = CachedValuesManager.getProjectPsiDependentCache(this) {
+        get() = getProjectContextDependentCache(this) {
             MAY_DERIVE_CLASS_INDEX.getElements(
-                name ?: return@getProjectPsiDependentCache emptyList(),
+                name ?: return@getProjectContextDependentCache emptyList(),
                 project,
                 GlobalSearchScope.allScope(project)
             ).asSequence().filter {
@@ -47,7 +47,7 @@ interface TableGenClassStatementEx : PsiNameIdentifierOwner, NavigationItem, Tab
      * Note that this currently doesn't include inline class instantiation values.
      */
     val allDerivedRecords: Sequence<TableGenRecord>
-        get() = CachedValuesManager.getProjectPsiDependentCache(this) {
+        get() = getProjectContextDependentCache(this) {
             RecursionManager.doPreventingRecursion(this, true) {
                 directivelyDerivedRecords + directivelyDerivedRecords.flatMap {
                     if (it is TableGenClassStatement) it.allDerivedRecords else emptySequence()
@@ -56,7 +56,7 @@ interface TableGenClassStatementEx : PsiNameIdentifierOwner, NavigationItem, Tab
         }.asSequence()
 
     override val mostDerivedRecords: Sequence<TableGenRecord>
-        get() = CachedValuesManager.getProjectPsiDependentCache(this) {
+        get() = getProjectContextDependentCache(this) {
             (allDerivedRecords + sequenceOf(this)).filter {
                 when (it) {
                     is TableGenClassStatement -> it.directivelyDerivedRecords.firstOrNull() == null

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenValueNodeEx.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenValueNodeEx.kt
@@ -11,8 +11,8 @@ import com.github.zero9178.mlirods.language.values.TableGenIntegerValue
 import com.github.zero9178.mlirods.language.values.TableGenStringValue
 import com.github.zero9178.mlirods.language.values.TableGenUnknownValue
 import com.github.zero9178.mlirods.language.values.TableGenValue
+import com.github.zero9178.mlirods.model.getProjectContextDependentCache
 import com.intellij.psi.PsiElement
-import com.intellij.psi.util.CachedValuesManager
 import com.intellij.util.containers.ConcurrentFactoryMap
 
 /**
@@ -71,11 +71,11 @@ interface TableGenValueNodeEx : PsiElement {
     /**
      * Performs constant evaluation of this value within the given context.
      *
-     * Results are cached per [context] and invalidated on any PSI modification. Implementations should not override
-     * this method but [evaluateInner] instead.
+     * Results are cached per [context] and invalidated on any PSI or include-context change. Implementations should not
+     * override this method but [evaluateInner] instead.
      */
     fun evaluate(context: TableGenEvaluationContext): TableGenValue =
-        CachedValuesManager.getProjectPsiDependentCache(this) { element ->
+        getProjectContextDependentCache(this) { element ->
             ConcurrentFactoryMap.createMap<TableGenEvaluationContext, TableGenValue> {
                 element.evaluateInner(it)
             }

--- a/src/main/kotlin/com/github/zero9178/mlirods/model/ContextDependentCache.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/model/ContextDependentCache.kt
@@ -1,0 +1,54 @@
+package com.github.zero9178.mlirods.model
+
+import com.github.zero9178.mlirods.language.TableGenLanguage
+import com.intellij.openapi.components.service
+import com.intellij.openapi.util.Key
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
+import com.intellij.psi.util.ParameterizedCachedValue
+import com.intellij.psi.util.PsiModificationTracker
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * One [Key] per [provider] class so that distinct call sites get their own cached-value slot on an element, mirroring
+ * how [CachedValuesManager.getProjectPsiDependentCache] derives its key from the provider class.
+ */
+private val keyForProviderClass = ConcurrentHashMap<Class<*>, Key<ParameterizedCachedValue<*, *>>>()
+
+/**
+ * Context-aware replacement for [CachedValuesManager.getProjectPsiDependentCache].
+ *
+ * Like the platform helper, the value computed by [provider] is cached per [element] and recomputed on PSI change.
+ * Unlike the platform helper it only tracks changes to TableGen PSI ([PsiModificationTracker.forLanguage]) rather than
+ * any language, as nothing cached here depends on the PSI of other languages. In addition, it is invalidated whenever
+ * the propagated [TableGenContext] of any file changes (see [TableGenContextService.contextChangedModificationTracker]).
+ *
+ * Almost every cross-file lookup in this project depends on these: resolution happens relative to the active context of
+ * a file (which files it includes, which defines are active, ...), and that context may change without any PSI edit —
+ * e.g. because the compile commands changed, or a TableGen file was added or removed. A plain
+ * [CachedValuesManager.getProjectPsiDependentCache] would keep serving stale results in those cases.
+ */
+fun <T, P : PsiElement> getProjectContextDependentCache(element: P, provider: (P) -> T): T {
+    @Suppress("UNCHECKED_CAST")
+    val key = keyForProviderClass.computeIfAbsent(provider.javaClass) {
+        Key.create("TableGenContextDependentCache#${it.name}")
+    } as Key<ParameterizedCachedValue<T, P>>
+
+    return CachedValuesManager.getManager(element.project).getParameterizedCachedValue(
+        element,
+        key,
+        { param: P ->
+            val service = param.project.service<TableGenContextService>()
+            val tableGenPsiTracker =
+                PsiModificationTracker.getInstance(param.project).forLanguage(TableGenLanguage.INSTANCE)
+            CachedValueProvider.Result.create(
+                provider(param),
+                tableGenPsiTracker,
+                service.contextChangedModificationTracker,
+            )
+        },
+        false,
+        element,
+    )
+}


### PR DESCRIPTION
Resolution and constant evaluation depend on a file's propagated TableGen context (its includes, active defines, ...), which can change independently of any PSI edit, e.g. because compile commands changed or a file was added or removed. The previous PSI-only cache kept serving stale results in that case, so replace it with a cache that also invalidates on context changes, scoped to TableGen PSI rather than all languages.