### PR TITLE
[Model] Index files with a context via a synthetic workspace module

### DIFF
--- a/src/main/kotlin/com/github/zero9178/mlirods/model/TableGenContext.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/model/TableGenContext.kt
@@ -4,7 +4,6 @@ import com.github.zero9178.mlirods.MyBundle
 import com.github.zero9178.mlirods.language.TableGenFileType
 import com.github.zero9178.mlirods.language.psi.TableGenFile
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.application.ReadResult
 import com.intellij.openapi.application.readAction
 import com.intellij.openapi.application.readAndBackgroundWriteAction
 import com.intellij.openapi.components.Service
@@ -33,6 +32,7 @@ import com.jetbrains.rd.util.firstOrNull
 import kotlinx.collections.immutable.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.update
 import org.jetbrains.annotations.TestOnly
 import java.io.Closeable
 import java.util.concurrent.locks.ReentrantReadWriteLock
@@ -85,10 +85,25 @@ class TableGenContextService(val project: Project, private val cs: CoroutineScop
 
     /**
      * Modification tracker which gets incremented each time a context changes.
-     * Note that it is a super-set of [includeResultModificationTracker].
      */
-    val contextChangedModificationTracker: ModificationTracker
-        field = SimpleModificationTracker()
+    val contextChangedModificationTracker: ModificationTracker = ModificationTracker { contextGeneration.value }
+
+    /**
+     * Generation counter bumped in lockstep with [contextChangedModificationTracker].
+     * Consumers can collect this [StateFlow] to react to context changes.
+     */
+    val contextGeneration: StateFlow<Long>
+        field = MutableStateFlow(0L)
+
+    /**
+     * Returns the set of files that currently have an active context, i.e. the compile-command roots and every file
+     * transitively included from one of them.
+     */
+    fun getFilesWithContext(): Set<VirtualFile> = myLock.read {
+        myFileToContexts.mapNotNullTo(mutableSetOf()) { (file, contexts) ->
+            file.takeIf { contexts.contextToUse != null }
+        }
+    }
 
     /**
      * [SharedFlow] that receives the compilation commands state any time that state has been finished applying.
@@ -96,6 +111,12 @@ class TableGenContextService(val project: Project, private val cs: CoroutineScop
     @TestOnly
     val finishedCompileCommands: SharedFlow<CompilationCommandsState>
         field = MutableStateFlow(CompilationCommandsState())
+
+    private val myFileToContexts: MutableMap<VirtualFile, Contexts> = mutableMapOf()
+    private val myLock = ReentrantReadWriteLock()
+    private val fileManager = cs.async {
+        (project.service<PsiManager>() as PsiManagerEx).fileManager
+    }
 
     init {
         // Refresh the world if any TableGen file is added or removed as any include resolution might now change.
@@ -129,8 +150,6 @@ class TableGenContextService(val project: Project, private val cs: CoroutineScop
         cs.launch(start = CoroutineStart.UNDISPATCHED) {
             // Apply value changes to all files mentioned in the compile commands.
             project.service<CompilationCommands>().stateFlow.collectLatest { state ->
-                if (state == CompilationCommandsState()) return@collectLatest
-
                 withBackgroundProgress(project, MyBundle.message("tableGen.progress.updatingContexts")) {
                     val startTime = System.nanoTime()
                     // Drive the fraction off the compile-command entries, the bulk of the work.
@@ -226,8 +245,8 @@ class TableGenContextService(val project: Project, private val cs: CoroutineScop
                 if (newContexts.firstOrNull() == myContexts.firstOrNull()) {
                     // TODO: Refresh currently only takes the active context into account meaning no refresh is needed
                     //       if the active context doesn't change.
-                    contextChangedModificationTracker.incModificationCount()
                     myContexts = newContexts
+                    contextGeneration.update { it + 1 }
                     return null
                 }
 
@@ -237,7 +256,7 @@ class TableGenContextService(val project: Project, private val cs: CoroutineScop
             } finally {
                 myLock.unlock(stamp)
             }
-            contextChangedModificationTracker.incModificationCount()
+            contextGeneration.update { it + 1 }
             if (newContext.firstOrNull()?.value?.includePaths != oldContext.firstOrNull()?.value?.includePaths) {
                 includeResultModificationTracker.incModificationCount()
             }
@@ -248,10 +267,10 @@ class TableGenContextService(val project: Project, private val cs: CoroutineScop
                 val instance = PsiManager.getInstance(project)
                 val fileManager = fileManager.await()
                 readAndBackgroundWriteAction {
-                    if (!file.isValid) return@readAndBackgroundWriteAction value(Unit)
+                    if (!file.isValid || project.isDisposed) return@readAndBackgroundWriteAction value(Unit)
 
-                    val tableGenFile = (instance.findFile(file) as? TableGenFile)
-                        ?: return@readAndBackgroundWriteAction value(
+                    val tableGenFile =
+                        (instance.findFile(file) as? TableGenFile) ?: return@readAndBackgroundWriteAction value(
                             Unit
                         )
                     val needsReparse = tableGenFile.usedMacros.any {
@@ -318,12 +337,6 @@ class TableGenContextService(val project: Project, private val cs: CoroutineScop
         private var myContexts = persistentMapOf<VirtualFile, TableGenContext>()
     }
 
-    private val myFileToContexts: MutableMap<VirtualFile, Contexts> = mutableMapOf()
-    private val myLock = ReentrantReadWriteLock()
-    private val fileManager = cs.async {
-        (project.service<PsiManager>() as PsiManagerEx).fileManager
-    }
-
     private fun getContextsForFile(file: VirtualFile) = myLock.read {
         myFileToContexts[file]?.let { return@read it }
         // Upgrade to a write lock otherwise. Note that multiple threads with the same key may be queuing for the write
@@ -342,7 +355,7 @@ class TableGenContextService(val project: Project, private val cs: CoroutineScop
 
         // Limit the read action from the Psi read to let write actions run as soon as possible.
         val (included, newContext) = readAction {
-            if (!updatedFile.isValid) return@readAction emptyList<VirtualFile>() to null
+            if (!updatedFile.isValid || project.isDisposed) return@readAction emptyList<VirtualFile>() to null
 
             val tableGenFile =
                 instance.findFile(updatedFile) as? TableGenFile ?: return@readAction emptyList<VirtualFile>() to null
@@ -352,6 +365,7 @@ class TableGenContextService(val project: Project, private val cs: CoroutineScop
                 it.includedFile
             }.toList() to tableGenFile.context
         }
+        checkCanceled()
         if (newContext == null) {
             myLock.write {
                 // Garbage collect deleted files.

--- a/src/main/kotlin/com/github/zero9178/mlirods/model/TableGenWorkspaceModelService.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/model/TableGenWorkspaceModelService.kt
@@ -1,0 +1,96 @@
+package com.github.zero9178.mlirods.model
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.components.serviceAsync
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.platform.backend.workspace.WorkspaceModel
+import com.intellij.platform.workspace.jps.entities.ContentRootEntity
+import com.intellij.platform.workspace.jps.entities.ModuleEntity
+import com.intellij.platform.workspace.storage.EntitySource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import org.jetbrains.annotations.TestOnly
+
+/**
+ * [EntitySource] tagging all workspace entities created by [TableGenWorkspaceModelService]. It is used to recognize and
+ * remove the entities we previously contributed when the set of included files changes.
+ */
+internal object TableGenEntitySource : EntitySource
+
+/**
+ * Name of the synthetic module holding the TableGen content roots.
+ */
+private const val MODULE_NAME = "TableGen Roots"
+
+/**
+ * Project service maintaining a synthetic module in the workspace model whose content roots are exactly the TableGen
+ * files that currently have a context, i.e. the compile-command roots and every file transitively included from one of
+ * them (see [TableGenContextService.getFilesWithContext]).
+ *
+ * Registering these files as content roots makes them indexed and part of
+ * [com.intellij.psi.search.GlobalSearchScope.allScope], even when they live outside the project's own content (e.g. the
+ * MLIR/LLVM headers a TableGen file includes).
+ */
+@Service(Service.Level.PROJECT)
+class TableGenWorkspaceModelService(private val project: Project, cs: CoroutineScope) {
+
+    companion object {
+        private val LOGGER = logger<TableGenWorkspaceModelService>()
+    }
+
+    /**
+     * [StateFlow] holding the latest [TableGenContextService.contextGeneration] whose files have finished being applied
+     * as content roots.
+     */
+    @TestOnly
+    val finishedGeneration: StateFlow<Long>
+        field = MutableStateFlow(-1L)
+
+    init {
+        cs.launch(start = CoroutineStart.UNDISPATCHED) {
+            val contextService = project.service<TableGenContextService>()
+            // Re-derive the content roots every time contexts change; 'collectLatest' coalesces bursts of changes.
+            contextService.contextGeneration.collectLatest { generation ->
+                val startTime = System.nanoTime()
+                updateContentRoots(contextService.getFilesWithContext())
+                val endTime = System.nanoTime()
+                LOGGER.info("Updating content roots took ${(endTime - startTime) / 1.0e9} seconds")
+                finishedGeneration.value = generation
+            }
+        }
+    }
+
+    private suspend fun updateContentRoots(files: Set<VirtualFile>) {
+        val workspaceModel = project.serviceAsync<WorkspaceModel>()
+        val urlManager = workspaceModel.getVirtualFileUrlManager()
+        workspaceModel.update("Update TableGen content roots") { storage ->
+
+            val roots = files.asSequence()
+                .map { urlManager.getOrCreateFromUrl(it.url) }
+                .toList()
+
+            // Drop the module contributed previously; removing it cascades to its content roots.
+            storage.entities(ModuleEntity::class.java)
+                .filter { it.entitySource == TableGenEntitySource }
+                .toList()
+                .forEach { storage.removeEntity(it) }
+
+            if (roots.isEmpty()) return@update
+
+            storage.addEntity(
+                ModuleEntity(MODULE_NAME, emptyList(), TableGenEntitySource) {
+                    contentRoots = roots.map { url ->
+                        ContentRootEntity(url, emptyList(), TableGenEntitySource)
+                    }
+                }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/model/TableGenWorkspaceModelStartup.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/model/TableGenWorkspaceModelStartup.kt
@@ -1,0 +1,21 @@
+package com.github.zero9178.mlirods.model
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+
+/**
+ * Eagerly instantiates [TableGenWorkspaceModelService] on project open so it starts tracking the compilation commands
+ * and contributing content roots without waiting for a TableGen file to be opened first.
+ */
+internal class TableGenWorkspaceModelStartup : ProjectActivity {
+    override suspend fun execute(project: Project) {
+        // Light test projects share a single project across tests and forbid module additions, which the service would
+        // attempt as soon as any test installs compilation commands. Tests that exercise the service (see
+        // WorkspaceModelTest) start it explicitly instead.
+        if (ApplicationManager.getApplication().isUnitTestMode) return
+
+        project.service<TableGenWorkspaceModelService>()
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -117,6 +117,8 @@
                          level="WARNING"
                          implementationClass="com.github.zero9178.mlirods.language.inspection.TableGenRedefinedFieldInspection"
         />
+        <postStartupActivity
+                implementation="com.github.zero9178.mlirods.model.TableGenWorkspaceModelStartup"/>
     </extensions>
 
     <extensions defaultExtensionNs="com.intellij.platform.lsp">

--- a/src/test/kotlin/com/github/zero9178/mlirods/WorkspaceModelTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/WorkspaceModelTest.kt
@@ -1,0 +1,123 @@
+package com.github.zero9178.mlirods
+
+import com.github.zero9178.mlirods.index.CLASS_INDEX
+import com.github.zero9178.mlirods.language.generated.psi.TableGenClassStatement
+import com.github.zero9178.mlirods.model.IncludePaths
+import com.github.zero9178.mlirods.model.TableGenContextService
+import com.github.zero9178.mlirods.model.TableGenEntitySource
+import com.github.zero9178.mlirods.model.TableGenWorkspaceModelService
+import com.intellij.openapi.components.service
+import com.intellij.openapi.roots.ProjectFileIndex
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.platform.backend.workspace.WorkspaceModel
+import com.intellij.platform.workspace.jps.entities.ModuleEntity
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.stubs.StubIndex
+import com.intellij.testFramework.HeavyPlatformTestCase
+import com.intellij.testFramework.IndexingTestUtil
+import com.intellij.testFramework.PlatformTestUtil
+import java.io.File
+
+/**
+ * Tests for [TableGenWorkspaceModelService]: every TableGen file that has a context – a compile-command root or a file
+ * transitively included from one – is contributed as a content root, so it is indexed and part of
+ * [GlobalSearchScope.allScope] even when it lives outside the project's own content.
+ *
+ * This uses a heavy (real) project because the service adds a module to the workspace model, which light test projects
+ * forbid.
+ */
+class WorkspaceModelTest : HeavyPlatformTestCase() {
+
+    /**
+     * Returns a function that applies a new set of include paths and waits until both the context has settled and
+     * [TableGenWorkspaceModelService] has contributed the resulting content roots.
+     */
+    private fun workspaceUpdater(): (Map<VirtualFile, IncludePaths>) -> Unit {
+        val setCompileCommands = compileCommandsUpdater(project)
+        val contextService = project.service<TableGenContextService>()
+        val workspaceService = project.service<TableGenWorkspaceModelService>()
+
+        return { map ->
+            // Sets the compile commands and waits for the context service to finish propagating them.
+            setCompileCommands(map)
+            // The workspace service reacts to the context change off the EDT and commits via an EDT write action, so
+            // keep pumping the event queue until it has caught up to the settled context generation.
+            PlatformTestUtil.waitWithEventsDispatching(
+                "TableGen content roots were not applied",
+                { workspaceService.finishedGeneration.value == contextService.contextGeneration.value },
+                10
+            )
+            IndexingTestUtil.waitUntilIndexesAreReady(project)
+        }
+    }
+
+    /**
+     * Creates a directory outside the project's content with a single TableGen [fileName] holding [content], returning
+     * the directory and the created file.
+     */
+    private fun createExternalDir(fileName: String, content: String): Pair<VirtualFile, VirtualFile> {
+        val ioDir = FileUtil.createTempDirectory("tablegen-external", null)
+        val ioFile = File(ioDir, fileName).apply { writeText(content) }
+        val lfs = LocalFileSystem.getInstance()
+        val dir = lfs.refreshAndFindFileByIoFile(ioDir)!!
+        val file = lfs.refreshAndFindFileByIoFile(ioFile)!!
+        return dir to file
+    }
+
+    private fun ourContentRootUrls(): Set<String> =
+        WorkspaceModel.getInstance(project).currentSnapshot.entities(ModuleEntity::class.java)
+            .filter { it.entitySource == TableGenEntitySource }
+            .flatMap { it.contentRoots }
+            .map { it.url.url }
+            .toSet()
+
+    fun `test root and its included files become content roots`() {
+        val (includeDir, included) = createExternalDir("included.td", "class Included;")
+        val (_, root) = createExternalDir("root.td", "include \"included.td\"")
+
+        val update = workspaceUpdater()
+        update(mapOf(root to IncludePaths(listOf(includeDir))))
+
+        // The root file and the file it includes both have a context, so both are content roots. The include directory
+        // itself is not.
+        assertContainsElements(ourContentRootUrls(), root.url, included.url)
+        assertDoesntContain(ourContentRootUrls(), includeDir.url)
+    }
+
+    fun `test switching root drops files that lost their context`() {
+        val (includeDir, included) = createExternalDir("included.td", "class Included;")
+        val (_, rootA) = createExternalDir("rootA.td", "include \"included.td\"")
+        val (_, rootB) = createExternalDir("rootB.td", "")
+
+        val update = workspaceUpdater()
+        update(mapOf(rootA to IncludePaths(listOf(includeDir))))
+        assertContainsElements(ourContentRootUrls(), rootA.url, included.url)
+
+        // 'rootB' includes nothing, so after the switch neither 'rootA' nor 'included' has a context anymore.
+        update(mapOf(rootB to IncludePaths(listOf(includeDir))))
+        val urls = ourContentRootUrls()
+        assertContainsElements(urls, rootB.url)
+        assertDoesntContain(urls, rootA.url)
+        assertDoesntContain(urls, included.url)
+    }
+
+    fun `test class in included file is indexed and in allScope`() {
+        val (includeDir, included) = createExternalDir("included.td", "class ExternalClass;")
+        val (_, root) = createExternalDir("root.td", "include \"included.td\"")
+
+        val update = workspaceUpdater()
+        update(mapOf(root to IncludePaths(listOf(includeDir))))
+
+        // The included file now counts as project content.
+        assertTrue(ProjectFileIndex.getInstance(project).isInContent(included))
+
+        // And its class is discoverable through the stub index in the all scope.
+        val classes = StubIndex.getElements(
+            CLASS_INDEX, "ExternalClass", project, GlobalSearchScope.allScope(project),
+            TableGenClassStatement::class.java
+        )
+        assertSize(1, classes)
+    }
+}


### PR DESCRIPTION
Prior to this PR, there was no project model for TableGen meaning the IDE did not recognize them as project content unless they were under a C++ include directory. While this is often the case, sometimes include directories specifically for TableGen files exist in which case they'd then not get indexed.

This PR therefore now registers all TableGen files who either have compilation commands or are included (transitively) by a file with a compilation command as part of the project.