### PR TITLE
[TableGen] Warn in a banner when a file has no active context

### DIFF
--- a/src/main/kotlin/com/github/zero9178/mlirods/language/TableGenNoContextNotificationProvider.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/TableGenNoContextNotificationProvider.kt
@@ -1,0 +1,74 @@
+package com.github.zero9178.mlirods.language
+
+import com.github.zero9178.mlirods.MyBundle
+import com.github.zero9178.mlirods.lsp.isTableGenFile
+import com.github.zero9178.mlirods.model.TableGenContextService
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.components.serviceOrNull
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.ui.EditorNotificationPanel
+import com.intellij.ui.EditorNotificationProvider
+import com.intellij.ui.EditorNotifications
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import java.util.function.Function
+import javax.swing.JComponent
+
+/**
+ * Marks a [FileEditor] whose no-context banner the user has dismissed. Because the flag lives on the editor instance,
+ * dismissal only lasts for as long as that editor is open: reopening the file creates a fresh editor and the banner
+ * appears again.
+ */
+internal val NO_CONTEXT_BANNER_DISMISSED = Key.create<Boolean>("TableGen.noContextBanner.dismissed")
+
+/**
+ * Refreshes the editor banners contributed by [TableGenNoContextNotificationProvider] whenever the set of files with a
+ * context may have changed, so that a banner appears or disappears as soon as a file gains or loses its context.
+ */
+@Service(Service.Level.PROJECT)
+private class TableGenNoContextNotificationService(project: Project, cs: CoroutineScope) {
+    init {
+        cs.launch {
+            project.service<TableGenContextService>().contextGeneration.collectLatest {
+                EditorNotifications.getInstance(project).updateAllNotifications()
+            }
+        }
+    }
+}
+
+/**
+ * Shows a banner in a TableGen file that has no active context, i.e. that is not reachable from any file with compile
+ * commands. Such a file's includes and references cannot be resolved, so the banner tells the user why analysis is
+ * incomplete. The banner can be dismissed via its close button for the lifetime of the editor.
+ */
+internal class TableGenNoContextNotificationProvider : EditorNotificationProvider, DumbAware {
+    override fun collectNotificationData(
+        project: Project, file: VirtualFile
+    ): Function<in FileEditor, out JComponent?>? {
+        if (!file.isTableGenFile) return null
+
+        val contextService = project.serviceOrNull<TableGenContextService>() ?: return null
+        // Start the refresher so the banner is re-evaluated once contexts change.
+        project.service<TableGenNoContextNotificationService>()
+        if (contextService.getActiveContext(file) != null) return null
+
+        return Function { editor ->
+            if (editor.getUserData(NO_CONTEXT_BANNER_DISMISSED) == true) return@Function null
+
+            EditorNotificationPanel(editor, EditorNotificationPanel.Status.Warning).apply {
+                text = MyBundle.message("tableGen.noContext.bannerText")
+                setCloseAction {
+                    editor.putUserData(NO_CONTEXT_BANNER_DISMISSED, true)
+                    EditorNotifications.getInstance(project).updateNotifications(file)
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/model/TableGenContext.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/model/TableGenContext.kt
@@ -406,10 +406,11 @@ class TableGenContextService(val project: Project, private val cs: CoroutineScop
     }
 
     /**
-     * Returns the context that is used to parse [virtualFile] or an empty context if none exists.
+     * Returns the context that is used to parse [virtualFile], or `null` if the file has no active context (i.e. it is
+     * not reachable from any file with compile commands).
      */
-    fun getActiveContext(virtualFile: VirtualFile): TableGenContext = myLock.read {
-        myFileToContexts[virtualFile.originalFileOrSelf()]?.contextToUse ?: TableGenContext()
+    fun getActiveContext(virtualFile: VirtualFile): TableGenContext? = myLock.read {
+        myFileToContexts[virtualFile.originalFileOrSelf()]?.contextToUse
     }
 
     @RequiresReadLock
@@ -440,7 +441,7 @@ class TableGenContextService(val project: Project, private val cs: CoroutineScop
         val instance = PsiManager.getInstance(project)
         file.virtualFile?.let { vf ->
             // Add from context.
-            val context = getActiveContext(vf)
+            val context = getActiveContext(vf) ?: return@let
             // Include all files in which we are included from. We do not need to recurse into them as all included
             // files prior to [file] are already part of [includedBeforeThis].
             // However, if we wanted to be very accurate, we should only allow definitions to be found in these files

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -117,6 +117,8 @@
                          level="WARNING"
                          implementationClass="com.github.zero9178.mlirods.language.inspection.TableGenRedefinedFieldInspection"
         />
+        <editorNotificationProvider
+                implementation="com.github.zero9178.mlirods.language.TableGenNoContextNotificationProvider"/>
         <postStartupActivity
                 implementation="com.github.zero9178.mlirods.model.TableGenWorkspaceModelStartup"/>
     </extensions>

--- a/src/main/resources/messages/MyBundle.properties
+++ b/src/main/resources/messages/MyBundle.properties
@@ -11,6 +11,8 @@ tableGen.lsp.enable=Use tblgen-lsp-server for additional diagnostics
 tableGen.progress.updatingContexts=Updating TableGen contexts
 tableGen.progress.updatingContext=Updating context for ''{0}''
 
+tableGen.noContext.bannerText=This file is not part of any TableGen compilation; includes and references cannot be fully resolved.
+
 tableGen.syntax.invalidLetMode=Expected one of ''append'' or ''prepend'' instead of ''{0}''
 
 tableGen.syntax.switch.missingDefault='!switch' requires a default value as its last argument

--- a/src/test/kotlin/com/github/zero9178/mlirods/TableGenNoContextNotificationTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/TableGenNoContextNotificationTest.kt
@@ -1,0 +1,42 @@
+package com.github.zero9178.mlirods
+
+import com.github.zero9178.mlirods.language.NO_CONTEXT_BANNER_DISMISSED
+import com.github.zero9178.mlirods.language.TableGenNoContextNotificationProvider
+import com.github.zero9178.mlirods.model.IncludePaths
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+class TableGenNoContextNotificationTest : BasePlatformTestCase() {
+
+    private val provider = TableGenNoContextNotificationProvider()
+
+    fun `test banner shown when file has no context`() {
+        val file = myFixture.configureByText("test.td", "class C;")
+        assertNotNull(provider.collectNotificationData(project, file.virtualFile))
+    }
+
+    fun `test no banner when file has a context`() {
+        val file = myFixture.configureByText("test.td", "class C;")
+        installCompileCommands(
+            project, mapOf(
+                file.virtualFile to IncludePaths(emptyList())
+            )
+        )
+        assertNull(provider.collectNotificationData(project, file.virtualFile))
+    }
+
+    fun `test dismissal is scoped to the editor instance`() {
+        val file = myFixture.configureByText("test.td", "class C;")
+        val data = provider.collectNotificationData(project, file.virtualFile)
+        assertNotNull(data)
+
+        val editor = FileEditorManager.getInstance(project).openFile(file.virtualFile, true).first()
+        // The banner is shown for a fresh editor...
+        assertNotNull(data!!.apply(editor))
+
+        // ...but hidden for an editor that has dismissed it (as the close button does). A reopened file gets a new
+        // editor without the flag, so the banner would appear again.
+        editor.putUserData(NO_CONTEXT_BANNER_DISMISSED, true)
+        assertNull(data.apply(editor))
+    }
+}


### PR DESCRIPTION
A TableGen file that is not reachable from any file with compile commands cannot have its includes and references resolved, leaving analysis silently incomplete. Surface this with an editor banner explaining why, refreshed as files gain or lose a context. The banner can be dismissed for the lifetime of the editor.

Fixes https://github.com/zero9178/IntelliJ-MLIR-ODS/issues/166