### PR TITLE
[TableGen] Report unresolvable include directives as errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an error for `include` directives whose path cannot be resolved to a file.
+
 ### Changed
 
 - Improved performance when compile commands or include paths change: a file is now only reparsed and reindexed when a macro it actually tests via `#ifdef`/`#ifndef` changes its defined state, rather than on every context update.

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/annotator/TableGenReferenceAnnotator.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/annotator/TableGenReferenceAnnotator.kt
@@ -1,0 +1,28 @@
+package com.github.zero9178.mlirods.language.annotator
+
+import com.github.zero9178.mlirods.MyBundle
+import com.github.zero9178.mlirods.language.generated.psi.TableGenIncludeDirective
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.HighlightSeverity
+
+/**
+ * Flags an [element] whose include path does not resolve to a file, be it because a directory along the path or the
+ * file itself is missing.
+ */
+private fun checkInclude(element: TableGenIncludeDirective, holder: AnnotationHolder) {
+    if (element.includedFile != null) return
+
+    val string = element.string ?: return
+    holder.newAnnotation(
+        HighlightSeverity.ERROR, MyBundle.message("tableGen.reference.unresolvedInclude", element.includeSuffix)
+    ).range(string).create()
+}
+
+private val ANNOTATIONS = arrayOf(
+    addAnnotationFor { element: TableGenIncludeDirective, holder -> checkInclude(element, holder) },
+)
+
+/**
+ * Annotator reporting problems with references, currently limited to include paths that do not resolve.
+ */
+internal class TableGenReferenceAnnotator : TableGenAnnotator(ANNOTATIONS.asIterable())

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -108,6 +108,9 @@
         <annotator language="TableGen"
                    implementationClass="com.github.zero9178.mlirods.language.annotator.TableGenConstantEvaluationAnnotator"
         />
+        <annotator language="TableGen"
+                   implementationClass="com.github.zero9178.mlirods.language.annotator.TableGenReferenceAnnotator"
+        />
         <localInspection language="TableGen"
                          shortName="TableGenRedefinedField"
                          bundle="messages.MyBundle"

--- a/src/main/resources/messages/MyBundle.properties
+++ b/src/main/resources/messages/MyBundle.properties
@@ -33,6 +33,8 @@ tableGen.syntax.missingArgument=Missing value for required template argument ''{
 
 tableGen.syntax.divisionByZero=Division by zero
 
+tableGen.reference.unresolvedInclude=Cannot resolve file ''{0}''
+
 tableGen.inspection.group=TableGen
 tableGen.inspection.redefinedField.displayName=Field redefinition
 tableGen.inspection.redefinedField.message=Redefinition of existing field ''{0}:{1}''

--- a/src/test/kotlin/com/github/zero9178/mlirods/TableGenReferenceAnnotatorTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/TableGenReferenceAnnotatorTest.kt
@@ -1,0 +1,55 @@
+package com.github.zero9178.mlirods
+
+import com.github.zero9178.mlirods.model.IncludePaths
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+class TableGenReferenceAnnotatorTest : BasePlatformTestCase() {
+
+    fun `test resolving include is not flagged`() {
+        myFixture.addFileToProject("sub/target.td", "")
+        val main = myFixture.configureByText(
+            "test.td", """
+            include "sub/target.td"
+        """.trimIndent()
+        )
+        installCompileCommands(
+            project, mapOf(main.virtualFile to IncludePaths(listOf(main.virtualFile.parent)))
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test include with a missing directory is flagged`() {
+        val main = myFixture.configureByText(
+            "test.td", """
+            include <error descr="Cannot resolve file 'missing/target.td'">"missing/target.td"</error>
+        """.trimIndent()
+        )
+        installCompileCommands(
+            project, mapOf(main.virtualFile to IncludePaths(listOf(main.virtualFile.parent)))
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test include with a missing file is flagged`() {
+        myFixture.addFileToProject("sub/keep.td", "")
+        val main = myFixture.configureByText(
+            "test.td", """
+            include <error descr="Cannot resolve file 'sub/missing.td'">"sub/missing.td"</error>
+        """.trimIndent()
+        )
+        installCompileCommands(
+            project, mapOf(main.virtualFile to IncludePaths(listOf(main.virtualFile.parent)))
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test unresolved include without a context is still flagged`() {
+        // Resolution is context-independent here: with no include paths the file cannot be found, so it is flagged.
+        myFixture.configureByText(
+            "test.td", """
+            include <error descr="Cannot resolve file 'missing/target.td'">"missing/target.td"</error>
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
+}


### PR DESCRIPTION
An 'include' whose path cannot be found is a hard error in TableGen, so surface it directly in the editor instead of silently leaving the directive unresolved.