### PR TITLE
[TableGen] Report unresolvable class references as errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ### Added
 
-- Added an error for `include` directives whose path cannot be resolved to a file. The error is suppressed in files not reachable from any compile commands, where includes cannot be resolved anyway.
+- Added an error for `include` directives whose path cannot be resolved to a file.
+- Added an error for class references that do not resolve to any class.
+- Reference-resolution errors are suppressed in files not reachable from any compile commands, where references cannot be resolved anyway.
 
 ### Changed
 

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/annotator/TableGenReferenceAnnotator.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/annotator/TableGenReferenceAnnotator.kt
@@ -1,6 +1,7 @@
 package com.github.zero9178.mlirods.language.annotator
 
 import com.github.zero9178.mlirods.MyBundle
+import com.github.zero9178.mlirods.language.generated.psi.TableGenAbstractClassRef
 import com.github.zero9178.mlirods.language.generated.psi.TableGenIncludeDirective
 import com.github.zero9178.mlirods.language.psi.TableGenFile
 import com.github.zero9178.mlirods.model.TableGenContextService
@@ -22,12 +23,25 @@ private fun checkInclude(element: TableGenIncludeDirective, holder: AnnotationHo
     ).range(string).create()
 }
 
+/**
+ * Flags a class reference (in an inheritance list, a `def`'s parent class, a value's type or a class instantiation)
+ * that does not resolve to any class.
+ */
+private fun checkClassReference(element: TableGenAbstractClassRef, holder: AnnotationHolder) {
+    if (element.referencedClass != null) return
+
+    holder.newAnnotation(
+        HighlightSeverity.ERROR, MyBundle.message("tableGen.reference.unresolvedClass", element.className)
+    ).range(element.classIdentifier).create()
+}
+
 private val ANNOTATIONS = arrayOf(
     addAnnotationFor { element: TableGenIncludeDirective, holder -> checkInclude(element, holder) },
+    addAnnotationFor { element: TableGenAbstractClassRef, holder -> checkClassReference(element, holder) },
 )
 
 /**
- * Annotator reporting problems with references, currently limited to include paths that do not resolve.
+ * Annotator reporting problems with references.
  */
 internal class TableGenReferenceAnnotator : TableGenAnnotator(ANNOTATIONS.asIterable()) {
     override fun annotate(element: PsiElement, holder: AnnotationHolder) {

--- a/src/main/resources/messages/MyBundle.properties
+++ b/src/main/resources/messages/MyBundle.properties
@@ -34,6 +34,7 @@ tableGen.syntax.missingArgument=Missing value for required template argument ''{
 tableGen.syntax.divisionByZero=Division by zero
 
 tableGen.reference.unresolvedInclude=Cannot resolve file ''{0}''
+tableGen.reference.unresolvedClass=Cannot resolve class ''{0}''
 
 tableGen.inspection.group=TableGen
 tableGen.inspection.redefinedField.displayName=Field redefinition

--- a/src/test/kotlin/com/github/zero9178/mlirods/TableGenReferenceAnnotatorTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/TableGenReferenceAnnotatorTest.kt
@@ -53,4 +53,39 @@ class TableGenReferenceAnnotatorTest : BasePlatformTestCase() {
         )
         myFixture.checkHighlighting()
     }
+
+    fun `test unresolved class is flagged`() {
+        val main = myFixture.configureByText(
+            "test.td", """
+            def D : <error descr="Cannot resolve class 'Missing'">Missing</error>;
+        """.trimIndent()
+        )
+        installCompileCommands(
+            project, mapOf(main.virtualFile to IncludePaths(emptyList()))
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test resolved class is not flagged`() {
+        val main = myFixture.configureByText(
+            "test.td", """
+            class Base;
+            def D : Base;
+        """.trimIndent()
+        )
+        installCompileCommands(
+            project, mapOf(main.virtualFile to IncludePaths(emptyList()))
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test unresolved class without a context is suppressed`() {
+        // Without a context, references cannot be resolved, so the annotator does not run there.
+        myFixture.configureByText(
+            "test.td", """
+            def D : Missing;
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
 }


### PR DESCRIPTION
Flag a class reference that resolves to no class, so an inheritance list, parent class, type or instantiation naming a missing class is surfaced directly in the editor. Like the include diagnostic, this is dropped in files without compile commands where references cannot be resolved.