### PR TITLE
[TableGen] Resolve #ifdef/#ifndef macros to their #define

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added an error for `include` directives whose path cannot be resolved to a file.
 - Added an error for class references that do not resolve to any class.
 - Reference-resolution errors are suppressed in files not reachable from any compile commands, where references cannot be resolved anyway.
+- Added reference resolution for `#ifdef`/`#ifndef` directives to their corresponding `#define`, including navigation, renaming from either side, and find usages.
 
 ### Changed
 

--- a/src/main/kotlin/com/github/zero9178/mlirods/index/TableGenDefineIndex.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/index/TableGenDefineIndex.kt
@@ -1,0 +1,17 @@
+package com.github.zero9178.mlirods.index
+
+import com.github.zero9178.mlirods.language.generated.psi.TableGenDefineDirective
+import com.intellij.psi.stubs.StringStubIndexExtension
+import com.intellij.psi.stubs.StubIndexKey
+
+/**
+ * Index mapping the name of a macro to the '#define' directives defining it.
+ */
+val DEFINE_INDEX = StubIndexKey.createIndexKey<String, TableGenDefineDirective>("DEFINE_INDEX")
+
+internal class TableGenDefineIndex : StringStubIndexExtension<TableGenDefineDirective>() {
+
+    override fun getKey(): StubIndexKey<String, TableGenDefineDirective> {
+        return DEFINE_INDEX
+    }
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/TableGen.bnf
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/TableGen.bnf
@@ -190,19 +190,29 @@ skipped_code_block ::=
 
 define_directive ::= '#define' IDENTIFIER {
     pin=1
-    methods=[toString]
-    implements=["com.github.zero9178.mlirods.language.psi.impl.TableGenMacroDirectiveEx"]
+    methods=[
+        toString
+        getPresentation
+    ]
+    implements=[
+        "com.github.zero9178.mlirods.language.psi.impl.TableGenMacroDirectiveEx"
+        "com.intellij.psi.PsiNameIdentifierOwner"
+        "com.intellij.psi.NavigatablePsiElement"
+    ]
     stubClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenMacroDirectiveStub"
-    mixin="com.github.zero9178.mlirods.language.psi.impl.TableGenMacroDirectiveMixin"
+    mixin="com.github.zero9178.mlirods.language.psi.impl.TableGenDefineDirectiveMixin"
     elementTypeClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenDefineDirectiveStubElementType"
 }
 
 ifdef_ifndef_directive ::= ('#ifdef' | '#ifndef') IDENTIFIER {
     pin=1
     methods=[toString]
-    implements=["com.github.zero9178.mlirods.language.psi.impl.TableGenMacroDirectiveEx"]
+    implements=[
+        "com.github.zero9178.mlirods.language.psi.impl.TableGenMacroDirectiveEx"
+        "com.intellij.psi.NavigatablePsiElement"
+    ]
     stubClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenMacroDirectiveStub"
-    mixin="com.github.zero9178.mlirods.language.psi.impl.TableGenMacroDirectiveMixin"
+    mixin="com.github.zero9178.mlirods.language.psi.impl.TableGenIfdefIfndefDirectiveMixin"
     elementTypeClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenIfdefIfndefDirectiveStubElementType"
 }
 

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/TableGenElementDescriptionProvider.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/TableGenElementDescriptionProvider.kt
@@ -32,6 +32,7 @@ internal class TableGenElementDescriptionProvider : ElementDescriptionProvider {
             is TableGenDefStatement -> "record"
             is TableGenDefvarStatement -> "variable"
             is TableGenClassStatement -> "class"
+            is TableGenDefineDirective -> "macro"
             is TableGenBangOperatorDefinition -> {
                 when (val parent = element.parent) {
                     is TableGenForeachOperatorValueNode -> "iterator"

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/TableGenFindUsageProvider.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/TableGenFindUsageProvider.kt
@@ -1,7 +1,7 @@
 package com.github.zero9178.mlirods.language
 
 import com.github.zero9178.mlirods.language.generated.psi.TableGenClassStatement
-import com.github.zero9178.mlirods.language.generated.psi.TableGenFieldBodyItem
+import com.github.zero9178.mlirods.language.generated.psi.TableGenDefineDirective
 import com.github.zero9178.mlirods.language.psi.TableGenIdentifierElement
 import com.intellij.lang.findUsages.FindUsagesProvider
 import com.intellij.psi.ElementDescriptionUtil
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.Nls
 
 internal class TableGenFindUsageProvider : FindUsagesProvider {
     override fun canFindUsagesFor(psiElement: PsiElement) = when (psiElement) {
-        is TableGenClassStatement, is TableGenIdentifierElement, is TableGenFieldBodyItem -> true
+        is TableGenClassStatement, is TableGenIdentifierElement, is TableGenDefineDirective -> true
         else -> false
     }
 

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenIfdefIfndefDirectiveManipulator.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenIfdefIfndefDirectiveManipulator.kt
@@ -1,0 +1,22 @@
+package com.github.zero9178.mlirods.language.psi
+
+import com.github.zero9178.mlirods.language.generated.psi.TableGenIfdefIfndefDirective
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.AbstractElementManipulator
+
+internal class TableGenIfdefIfndefDirectiveManipulator :
+    AbstractElementManipulator<TableGenIfdefIfndefDirective>() {
+    override fun handleContentChange(
+        element: TableGenIfdefIfndefDirective, range: TextRange, newContent: String
+    ): TableGenIfdefIfndefDirective? {
+        val identifier = element.identifier ?: return null
+
+        val newName = range.shiftLeft(getRangeInElement(element).startOffset).replace(identifier.text, newContent)
+        identifier.replace(createIdentifier(element.project, newName))
+        return element
+    }
+
+    override fun getRangeInElement(element: TableGenIfdefIfndefDirective): TextRange {
+        return element.identifier?.textRangeInParent ?: TextRange.EMPTY_RANGE
+    }
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenMacroReference.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenMacroReference.kt
@@ -1,0 +1,51 @@
+package com.github.zero9178.mlirods.language.psi
+
+import com.github.zero9178.mlirods.index.DEFINE_INDEX
+import com.github.zero9178.mlirods.index.getElements
+import com.github.zero9178.mlirods.language.generated.psi.TableGenIfdefIfndefDirective
+import com.github.zero9178.mlirods.model.TableGenIncludedSearchScope
+import com.github.zero9178.mlirods.model.getProjectContextDependentCache
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.IndexNotReadyException
+import com.intellij.psi.PsiElementResolveResult
+import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.ResolveResult
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.util.concurrency.annotations.RequiresReadLock
+
+/**
+ * Implements the lookup procedure resolving the macro name tested by a '#ifdef'/'#ifndef' directive to the
+ * corresponding '#define' directive(s).
+ */
+class TableGenMacroReference(element: TableGenIfdefIfndefDirective) :
+    PsiReferenceBase.Poly<TableGenIfdefIfndefDirective>(element) {
+
+    override fun hashCode(): Int {
+        return element.hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return element === (other as? TableGenMacroReference)?.element
+    }
+
+    @RequiresReadLock
+    override fun multiResolve(incompleteCode: Boolean): Array<out ResolveResult> =
+        getProjectContextDependentCache(element) { element ->
+            val name = element.macroName ?: return@getProjectContextDependentCache emptyArray()
+
+            val project = element.project
+            if (DumbService.isDumb(project)) throw IndexNotReadyException.create()
+
+            // A macro may be defined by this file or by any of the files it includes.
+            DEFINE_INDEX.getElements(
+                name,
+                project,
+                GlobalSearchScope.union(
+                    arrayOf(
+                        TableGenIncludedSearchScope(element, project),
+                        GlobalSearchScope.fileScope(element.containingFile)
+                    )
+                )
+            ).map { res -> PsiElementResolveResult(res) }.toTypedArray()
+        }
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenDefineDirectiveMixin.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenDefineDirectiveMixin.kt
@@ -1,0 +1,30 @@
+package com.github.zero9178.mlirods.language.psi.impl
+
+import com.github.zero9178.mlirods.language.generated.psi.TableGenDefineDirective
+import com.github.zero9178.mlirods.language.psi.createIdentifier
+import com.github.zero9178.mlirods.language.stubs.impl.TableGenMacroDirectiveStub
+import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
+import com.intellij.psi.stubs.IStubElementType
+
+/**
+ * Mixin for the '#define' directive.
+ */
+abstract class TableGenDefineDirectiveMixin : TableGenMacroDirectiveMixin, TableGenDefineDirective {
+
+    constructor(node: ASTNode) : super(node)
+
+    constructor(stub: TableGenMacroDirectiveStub, stubType: IStubElementType<*, *>) : super(stub, stubType)
+
+    // Backed by the stub so that the name can be queried without loading the AST.
+    override fun getName(): String? = macroName
+
+    override fun getNameIdentifier(): PsiElement? = identifier
+
+    override fun setName(name: String): PsiElement {
+        identifier?.replace(createIdentifier(project, name))
+        return this
+    }
+
+    override fun getTextOffset(): Int = identifier?.textOffset ?: super.getTextOffset()
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenIfdefIfndefDirectiveMixin.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenIfdefIfndefDirectiveMixin.kt
@@ -1,0 +1,19 @@
+package com.github.zero9178.mlirods.language.psi.impl
+
+import com.github.zero9178.mlirods.language.generated.psi.TableGenIfdefIfndefDirective
+import com.github.zero9178.mlirods.language.psi.TableGenMacroReference
+import com.github.zero9178.mlirods.language.stubs.impl.TableGenMacroDirectiveStub
+import com.intellij.lang.ASTNode
+import com.intellij.psi.stubs.IStubElementType
+
+/**
+ * Mixin for the '#ifdef'/'#ifndef' directives, whose macro name references the corresponding '#define' directive.
+ */
+abstract class TableGenIfdefIfndefDirectiveMixin : TableGenMacroDirectiveMixin, TableGenIfdefIfndefDirective {
+
+    constructor(node: ASTNode) : super(node)
+
+    constructor(stub: TableGenMacroDirectiveStub, stubType: IStubElementType<*, *>) : super(stub, stubType)
+
+    override fun getReference() = TableGenMacroReference(this)
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenMacroDirectiveMixin.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenMacroDirectiveMixin.kt
@@ -7,7 +7,7 @@ import com.intellij.lang.ASTNode
 import com.intellij.psi.stubs.IStubElementType
 
 /**
- * Mixin shared by the preprocessor directives carrying a macro name ('#define', '#ifdef' and '#ifndef').
+ * Base mixin shared by the preprocessor directives carrying a macro name ('#define', '#ifdef' and '#ifndef').
  * The macro name is stored on the stub so that it can be queried without reparsing the file.
  */
 abstract class TableGenMacroDirectiveMixin : StubBasedPsiElementBase<TableGenMacroDirectiveStub>,

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/TableGenStubFileElementType.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/TableGenStubFileElementType.kt
@@ -29,7 +29,7 @@ class TableGenStubFileElementType :
     }
 
     override fun getStubVersion(): Int {
-        return 21
+        return 23
     }
 
     override fun deserialize(

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/impl/TableGenMacroDirectiveStub.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/impl/TableGenMacroDirectiveStub.kt
@@ -1,5 +1,6 @@
 package com.github.zero9178.mlirods.language.stubs.impl
 
+import com.github.zero9178.mlirods.index.DEFINE_INDEX
 import com.github.zero9178.mlirods.language.generated.psi.impl.TableGenDefineDirectiveImpl
 import com.github.zero9178.mlirods.language.generated.psi.impl.TableGenIfdefIfndefDirectiveImpl
 import com.github.zero9178.mlirods.language.psi.impl.TableGenMacroDirectiveEx
@@ -47,7 +48,11 @@ private class TableGenMacroDirectiveStubImpl(
 
 class TableGenDefineDirectiveStubElementType(debugName: String) : TableGenAbstractMacroDirectiveStubElementType(
     debugName, ::TableGenDefineDirectiveImpl
-)
+) {
+    override fun indexStub(stub: TableGenMacroDirectiveStub, sink: IndexSink) {
+        stub.macroName?.let { sink.occurrence(DEFINE_INDEX, it) }
+    }
+}
 
 class TableGenIfdefIfndefDirectiveStubElementType(debugName: String) : TableGenAbstractMacroDirectiveStubElementType(
     debugName, ::TableGenIfdefIfndefDirectiveImpl

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -39,6 +39,9 @@
         <lang.elementManipulator forClass="com.github.zero9178.mlirods.language.generated.psi.TableGenIncludeDirective"
                                  implementationClass="com.github.zero9178.mlirods.language.psi.TableGenIncludeManipulator"/>
         <lang.elementManipulator
+                forClass="com.github.zero9178.mlirods.language.generated.psi.TableGenIfdefIfndefDirective"
+                implementationClass="com.github.zero9178.mlirods.language.psi.TableGenIfdefIfndefDirectiveManipulator"/>
+        <lang.elementManipulator
                 forClass="com.github.zero9178.mlirods.language.generated.psi.TableGenIdentifierValueNode"
                 implementationClass="com.github.zero9178.mlirods.language.psi.TableGenIdentifierValueNodeManipulator"/>
         <lang.elementManipulator forClass="com.github.zero9178.mlirods.language.generated.psi.TableGenClassRef"
@@ -65,6 +68,7 @@
         <stubIndex implementation="com.github.zero9178.mlirods.index.TableGenClassIndex"/>
         <stubIndex implementation="com.github.zero9178.mlirods.index.TableGenAllClassesIndex"/>
         <stubIndex implementation="com.github.zero9178.mlirods.index.TableGenMayDeriveClassIndex"/>
+        <stubIndex implementation="com.github.zero9178.mlirods.index.TableGenDefineIndex"/>
         <elementDescriptionProvider
                 implementation="com.github.zero9178.mlirods.language.TableGenElementDescriptionProvider"/>
         <usageTypeProvider

--- a/src/test/kotlin/com/github/zero9178/mlirods/FindUsageTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/FindUsageTest.kt
@@ -36,6 +36,17 @@ class FindUsageTest : BasePlatformTestCase() {
             })
     }
 
+    fun `test define`() {
+        val actual = myFixture.testFindUsagesUsingAction("Define.td").filterIsInstance<PsiElementUsage>()
+        assertUnorderedCollection(
+            actual, {
+                assertInstanceOf<TableGenIfdefIfndefDirective>(it.element)
+            },
+            {
+                assertInstanceOf<TableGenIfdefIfndefDirective>(it.element)
+            })
+    }
+
     fun `test include`() {
         val includeFile = myFixture.copyFileToProject("Include.td")
         val defFile = myFixture.copyFileToProject("Def.td")

--- a/src/test/kotlin/com/github/zero9178/mlirods/ReferenceTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/ReferenceTest.kt
@@ -427,6 +427,87 @@ class ReferenceTest : BasePlatformTestCase() {
         assertNull(item.referencedTemplateArgDecl)
     }
 
+    fun `test ifdef resolves to define`() {
+        val element = doTestInline<TableGenDefineDirective>(
+            """
+            #define FOO
+            #ifdef <caret>FOO
+            #endif
+        """.trimIndent()
+        )
+        assertEquals("FOO", element.macroName)
+    }
+
+    fun `test ifdef resolves to define after it`() {
+        // Resolution is not order-sensitive within a file: a '#define' following the '#ifdef' still resolves.
+        val element = doTestInline<TableGenDefineDirective>(
+            """
+            #ifdef <caret>FOO
+            #endif
+            #define FOO
+        """.trimIndent()
+        )
+        assertEquals("FOO", element.macroName)
+    }
+
+    fun `test ifndef resolves to define`() {
+        val element = doTestInline<TableGenDefineDirective>(
+            """
+            #ifndef <caret>FOO
+            #define FOO
+            #endif
+        """.trimIndent()
+        )
+        assertEquals("FOO", element.macroName)
+    }
+
+    fun `test ifdef resolves to define in include`() {
+        val testFile = myFixture.createFile(
+            "test.td", """
+            #ifdef <caret>FOO
+            #endif
+        """.trimIndent()
+        )
+        myFixture.createFile(
+            "define.td", """
+            #define FOO
+        """.trimIndent()
+        )
+        val root = myFixture.createFile(
+            "HasCompileCommands.td", """
+            include "define.td"
+            include "test.td"
+        """.trimIndent()
+        )
+        installCompileCommands(
+            project, mapOf(
+                root to IncludePaths(listOf(testFile.parent))
+            )
+        )
+
+        myFixture.configureFromExistingVirtualFile(testFile)
+        val element = assertInstanceOf(myFixture.elementAtCaret, TableGenDefineDirective::class.java)
+        assertEquals("FOO", element.macroName)
+        assertEquals("define.td", element.containingFile.name)
+    }
+
+    fun `test ifndef unresolved`() {
+        // A macro that is never '#define'd resolves to nothing (soft reference).
+        val mainVF = myFixture.createFile(
+            "test.td", """
+            #ifndef <caret>FOO
+            #endif
+        """.trimIndent()
+        )
+        installCompileCommands(
+            project, mapOf(
+                mainVF to IncludePaths(emptyList())
+            )
+        )
+        myFixture.configureFromExistingVirtualFile(mainVF)
+        assertNull(myFixture.file.findReferenceAt(myFixture.caretOffset)?.resolve())
+    }
+
     override fun getTestDataPath(): String? {
         return "src/test/testData/references"
     }

--- a/src/test/kotlin/com/github/zero9178/mlirods/RenameTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/RenameTest.kt
@@ -4,6 +4,40 @@ import com.github.zero9178.mlirods.model.IncludePaths
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 
 class RenameTest : BasePlatformTestCase() {
+    fun `test rename macro from ifdef`() {
+        // Renaming from an '#ifdef' renames the '#define' declaration and updates its identifier via the manipulator.
+        doTestInline(
+            "BAR",
+            """
+            #define FOO
+            #ifdef <caret>FOO
+            #endif
+        """.trimIndent(),
+            """
+            #define BAR
+            #ifdef BAR
+            #endif
+        """.trimIndent()
+        )
+    }
+
+    fun `test rename macro from define`() {
+        // Renaming the '#define' declaration updates the '#ifdef' reference via the manipulator.
+        doTestInline(
+            "BAR",
+            """
+            #define <caret>FOO
+            #ifndef FOO
+            #endif
+        """.trimIndent(),
+            """
+            #define BAR
+            #ifndef BAR
+            #endif
+        """.trimIndent()
+        )
+    }
+
     fun `test rename include`() {
         val testFile = myFixture.copyFileToProject("test.td")
         val virtualFile = myFixture.copyFileToProject("HasCompileCommands.td")

--- a/src/test/testData/findUsages/Define.td
+++ b/src/test/testData/findUsages/Define.td
@@ -1,0 +1,8 @@
+
+#define <caret>FOO
+
+#ifdef FOO
+#endif
+
+#ifndef FOO
+#endif


### PR DESCRIPTION
Treat a #define as the declaration of a preprocessor macro and let #ifdef/#ifndef directives reference it. This enables navigation, renaming from either side, and find usages for macros.

Fixes https://github.com/zero9178/IntelliJ-MLIR-ODS/issues/131 Fixes https://github.com/zero9178/IntelliJ-MLIR-ODS/issues/132