### PR TITLE
[TableGen] Report accesses to non-existent fields as errors

### DIFF
--- a/src/main/kotlin/com/github/zero9178/mlirods/language/annotator/TableGenReferenceAnnotator.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/annotator/TableGenReferenceAnnotator.kt
@@ -2,8 +2,10 @@ package com.github.zero9178.mlirods.language.annotator
 
 import com.github.zero9178.mlirods.MyBundle
 import com.github.zero9178.mlirods.language.generated.psi.TableGenAbstractClassRef
+import com.github.zero9178.mlirods.language.generated.psi.TableGenFieldAccessValueNode
 import com.github.zero9178.mlirods.language.generated.psi.TableGenIncludeDirective
 import com.github.zero9178.mlirods.language.psi.TableGenFile
+import com.github.zero9178.mlirods.language.types.TableGenRecordType
 import com.github.zero9178.mlirods.model.TableGenContextService
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.HighlightSeverity
@@ -35,9 +37,28 @@ private fun checkClassReference(element: TableGenAbstractClassRef, holder: Annot
     ).range(element.classIdentifier).create()
 }
 
+/**
+ * Flags a field access `x.field` whose left-hand side is a record that does not contain (nor inherit) a field named
+ * `field`. Field accesses on a non-record value, or on a record whose class reference is itself unresolved, are left
+ * alone: the former is not a reference problem and the latter is already reported as an unresolved class.
+ */
+private fun checkFieldAccess(element: TableGenFieldAccessValueNode, holder: AnnotationHolder) {
+    val fieldIdentifier = element.fieldIdentifier ?: return
+    val fieldName = element.fieldName ?: return
+
+    val type = element.valueNode.type as? TableGenRecordType ?: return
+    val record = type.record ?: return
+    if (record.fields[fieldName] != null) return
+
+    holder.newAnnotation(
+        HighlightSeverity.ERROR, MyBundle.message("tableGen.reference.unknownField", type.recordName, fieldName)
+    ).range(fieldIdentifier).create()
+}
+
 private val ANNOTATIONS = arrayOf(
     addAnnotationFor { element: TableGenIncludeDirective, holder -> checkInclude(element, holder) },
     addAnnotationFor { element: TableGenAbstractClassRef, holder -> checkClassReference(element, holder) },
+    addAnnotationFor { element: TableGenFieldAccessValueNode, holder -> checkFieldAccess(element, holder) },
 )
 
 /**

--- a/src/main/resources/messages/MyBundle.properties
+++ b/src/main/resources/messages/MyBundle.properties
@@ -35,6 +35,7 @@ tableGen.syntax.divisionByZero=Division by zero
 
 tableGen.reference.unresolvedInclude=Cannot resolve file ''{0}''
 tableGen.reference.unresolvedClass=Cannot resolve class ''{0}''
+tableGen.reference.unknownField=Record ''{0}'' has no field named ''{1}''
 
 tableGen.inspection.group=TableGen
 tableGen.inspection.redefinedField.displayName=Field redefinition

--- a/src/test/kotlin/com/github/zero9178/mlirods/TableGenReferenceAnnotatorTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/TableGenReferenceAnnotatorTest.kt
@@ -88,4 +88,76 @@ class TableGenReferenceAnnotatorTest : BasePlatformTestCase() {
         )
         myFixture.checkHighlighting()
     }
+
+    fun `test access to a non-existent field is flagged`() {
+        val main = myFixture.configureByText(
+            "test.td", """
+            class Base {
+                int x = 0;
+            }
+            defvar v = Base<>.<error descr="Record 'Base' has no field named 'nope'">nope</error>;
+        """.trimIndent()
+        )
+        installCompileCommands(
+            project, mapOf(main.virtualFile to IncludePaths(emptyList()))
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test access to an existing field is not flagged`() {
+        val main = myFixture.configureByText(
+            "test.td", """
+            class Base {
+                int x = 0;
+            }
+            defvar v = Base<>.x;
+        """.trimIndent()
+        )
+        installCompileCommands(
+            project, mapOf(main.virtualFile to IncludePaths(emptyList()))
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test access to an inherited field is not flagged`() {
+        val main = myFixture.configureByText(
+            "test.td", """
+            class Base {
+                int x = 0;
+            }
+            class Derived : Base;
+            defvar v = Derived<>.x;
+        """.trimIndent()
+        )
+        installCompileCommands(
+            project, mapOf(main.virtualFile to IncludePaths(emptyList()))
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test field access on an unresolved class is not double-flagged`() {
+        // The unresolved class is already reported; the field access on it should stay quiet.
+        val main = myFixture.configureByText(
+            "test.td", """
+            defvar v = <error descr="Cannot resolve class 'Missing'">Missing</error><>.nope;
+        """.trimIndent()
+        )
+        installCompileCommands(
+            project, mapOf(main.virtualFile to IncludePaths(emptyList()))
+        )
+        myFixture.checkHighlighting()
+    }
+
+    fun `test unknown field without a context is suppressed`() {
+        // Without a context, field resolution cannot run, so the annotator does not fire.
+        myFixture.configureByText(
+            "test.td", """
+            class Base {
+                int x = 0;
+            }
+            defvar v = Base<>.nope;
+        """.trimIndent()
+        )
+        myFixture.checkHighlighting()
+    }
 }


### PR DESCRIPTION
Flag a field access whose left-hand side is a resolved record that neither defines nor inherits the named field. Accesses on non-record values or on unresolved classes are left alone, the latter already being covered by the unresolved-class diagnostic.