### PR TITLE
[TableGen] Highlight !cast and !filter as bang operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added an error for class references that do not resolve to any class.
 - Reference-resolution errors are suppressed in files not reachable from any compile commands, where references cannot be resolved anyway.
 - Added reference resolution for `#ifdef`/`#ifndef` directives to their corresponding `#define`, including navigation, renaming from either side, and find usages.
+- The `!cast` and `!filter` operators are now highlighted as bang operators.
 
 ### Changed
 

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/TableGenTokens.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/TableGenTokens.kt
@@ -71,7 +71,9 @@ val PREPROCESSOR_TOKENS = TokenSet.create(
 )
 val BANG_OPERATORS = TokenSet.create(
     TableGenTypes.BANG_OPERATOR,
+    TableGenTypes.BANG_CAST,
     TableGenTypes.BANG_COND,
+    TableGenTypes.BANG_FILTER,
     TableGenTypes.BANG_FOREACH,
     TableGenTypes.BANG_FOLDL,
     TableGenTypes.BANG_SWITCH,


### PR DESCRIPTION
The !cast and !filter operators had dedicated tokens that were absent from the set driving bang operator syntax highlighting, so they were not colored consistently with the other bang operators.