### PR TITLE
[TableGen] Avoid claiming files owned by another module

### DIFF
--- a/src/main/kotlin/com/github/zero9178/mlirods/model/TableGenWorkspaceModelService.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/model/TableGenWorkspaceModelService.kt
@@ -1,20 +1,28 @@
 package com.github.zero9178.mlirods.model
 
+import com.intellij.openapi.application.readAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.components.serviceAsync
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.platform.backend.workspace.WorkspaceModel
 import com.intellij.platform.workspace.jps.entities.ContentRootEntity
 import com.intellij.platform.workspace.jps.entities.ModuleEntity
+import com.intellij.platform.workspace.storage.EntityChange
 import com.intellij.platform.workspace.storage.EntitySource
+import com.intellij.platform.workspace.storage.VersionedStorageChange
+import com.intellij.platform.workspace.storage.WorkspaceEntity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.launch
 import org.jetbrains.annotations.TestOnly
 
@@ -56,8 +64,15 @@ class TableGenWorkspaceModelService(private val project: Project, cs: CoroutineS
     init {
         cs.launch(start = CoroutineStart.UNDISPATCHED) {
             val contextService = project.service<TableGenContextService>()
-            // Re-derive the content roots every time contexts change; 'collectLatest' coalesces bursts of changes.
-            contextService.contextGeneration.collectLatest { generation ->
+            val workspaceModel = project.serviceAsync<WorkspaceModel>()
+
+            // Re-derive the content roots on two signals:
+            //  - the set of files-with-context changed (contextGeneration), and
+            //  - another module's roots changed, e.g. CMake reconfigured. updateContentRoots drops files another
+            //    module already owns, so that decision goes stale when those modules' content roots move.
+            val foreignRootChanges = workspaceModel.eventLog.filter { it.hasForeignRootChange() }
+            merge(contextService.contextGeneration.map { }, foreignRootChanges.map { }).collectLatest {
+                val generation = contextService.contextGeneration.value
                 val startTime = System.nanoTime()
                 updateContentRoots(contextService.getFilesWithContext())
                 val endTime = System.nanoTime()
@@ -67,14 +82,38 @@ class TableGenWorkspaceModelService(private val project: Project, cs: CoroutineS
         }
     }
 
+    /**
+     * Whether [this] change touches a module or content root that is not one of ours. Such a change may shift which
+     * files other modules own, invalidating the filtering [updateContentRoots] performs; changes to our own entities
+     * (tagged [TableGenEntitySource]) are ignored so reacting to them cannot loop back into another update.
+     */
+    private fun VersionedStorageChange.hasForeignRootChange(): Boolean =
+        getChanges(ModuleEntity::class.java).any { it.isForeign() } ||
+                getChanges(ContentRootEntity::class.java).any { it.isForeign() }
+
+    private fun EntityChange<out WorkspaceEntity>.isForeign(): Boolean {
+        val entity = newEntity ?: oldEntity
+        return entity != null && entity.entitySource != TableGenEntitySource
+    }
+
     private suspend fun updateContentRoots(files: Set<VirtualFile>) {
         val workspaceModel = project.serviceAsync<WorkspaceModel>()
         val urlManager = workspaceModel.getVirtualFileUrlManager()
-        workspaceModel.update("Update TableGen content roots") { storage ->
 
-            val roots = files.asSequence()
-                .map { urlManager.getOrCreateFromUrl(it.url) }
-                .toList()
+        // Filter out files another module already owns before mutating the model. Contributing a content root for them
+        // would overlap that module's content and make the file ambiguously belong to two modules.
+        // Note: Technically [WorkspaceModel.eventLog] does not guarantee this index to be up-to-date but there is
+        // currently no better mechanism.
+        val fileIndex = ProjectFileIndex.getInstance(project)
+        val ownFiles = readAction {
+            files.filter { file ->
+                val owner = fileIndex.getModuleForFile(file)
+                owner == null || owner.name == MODULE_NAME
+            }
+        }
+
+        workspaceModel.update("Update TableGen content roots") { storage ->
+            val roots = ownFiles.map { urlManager.getOrCreateFromUrl(it.url) }
 
             // Drop the module contributed previously; removing it cascades to its content roots.
             storage.entities(ModuleEntity::class.java)


### PR DESCRIPTION
The TableGen module contributes a content root for every file that has a context. If another module (e.g. one contributed by CMake) already owns such a file, contributing our own root makes the file ambiguously belong to two modules.

Skip files an existing module already owns, and re-derive the content roots not only when the set of files-with-context changes but also when a foreign module's roots change (such as after a CMake reconfigure), since that ownership decision can otherwise go stale.