### PR TITLE
[TableGen] Report template arguments whose value type is not assignable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added an error for accesses to a field that the surrounding record neither defines nor inherits.
 - Added an editor banner warning that a file's includes and references cannot be resolved when the file is not reachable from any file with compile commands.
 - `multiclass` statements now introduce a scope, so that references within them resolve to the multiclass' template arguments and to statements declared inside it.
+- Added an error for a template argument whose value is of a type that is not assignable to the argument's declared type.
 
 ### Changed
 

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/annotator/TableGenSemanticAnnotator.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/annotator/TableGenSemanticAnnotator.kt
@@ -14,6 +14,7 @@ import com.intellij.lang.annotation.HighlightSeverity
  * 1. No template argument is assigned more than once.
  * 2. Every argument resolves to a template argument declaration.
  * 3. Every template argument declaration without a default value is assigned a value.
+ * 4. Every argument's value is of a type assignable to its template argument declaration.
  */
 private fun checkArguments(element: TableGenAbstractClassRef, holder: AnnotationHolder) {
     val targetClass = element.referencedClass ?: return
@@ -24,6 +25,7 @@ private fun checkArguments(element: TableGenAbstractClassRef, holder: Annotation
         val decl = item.referencedTemplateArgDecl
         if (decl != null) {
             itemsByDecl.getOrPut(decl) { mutableListOf() }.add(item)
+            checkArgumentType(item, decl, holder)
             continue
         }
 
@@ -57,6 +59,29 @@ private fun checkArguments(element: TableGenAbstractClassRef, holder: Annotation
             HighlightSeverity.ERROR, MyBundle.message("tableGen.syntax.missingArgument", decl.name ?: "")
         ).range(element.classIdentifier).create()
     }
+}
+
+/**
+ * Flags an argument [item] whose value is of a type that cannot be assigned to its resolved template argument
+ * declaration [decl]. Mirroring TableGen, the check uses type convertibility; if either type is unknown (or otherwise
+ * indeterminate) no error is reported.
+ */
+private fun checkArgumentType(
+    item: TableGenArgValueItem, decl: TableGenTemplateArgDecl, holder: AnnotationHolder
+) {
+    val valueNode = item.valueNode ?: return
+    val declaredType = decl.typeNode.toType()
+    val valueType = valueNode.type
+
+    // Only report a definite mismatch; an indeterminate result (null) leaves the argument alone.
+    if (valueType.isConvertibleTo(declaredType) != false) return
+
+    holder.newAnnotation(
+        HighlightSeverity.ERROR, MyBundle.message(
+            "tableGen.syntax.argumentTypeMismatch",
+            valueType.toString(), decl.name ?: "", declaredType.toString()
+        )
+    ).range(valueNode).create()
 }
 
 private val ANNOTATIONS = arrayOf(

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenFieldScopeNode.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenFieldScopeNode.kt
@@ -1,11 +1,13 @@
 package com.github.zero9178.mlirods.language.psi
 
 import com.github.zero9178.mlirods.language.generated.psi.TableGenClassRef
+import com.github.zero9178.mlirods.language.generated.psi.TableGenClassStatement
 import com.github.zero9178.mlirods.language.generated.psi.TableGenFieldBodyItem
 import com.github.zero9178.mlirods.language.generated.psi.TableGenTemplateArgDecl
 import com.github.zero9178.mlirods.language.generated.psi.TableGenValueNode
 import com.github.zero9178.mlirods.language.stubs.disallowTreeLoading
 import com.github.zero9178.mlirods.model.getProjectContextDependentCache
+import com.intellij.openapi.util.RecursionManager
 import com.intellij.psi.PsiElement
 
 /**
@@ -107,6 +109,42 @@ interface TableGenFieldScopeNode : TableGenIdentifierScopeNode {
      * Returns a sequence of all references to base classes that should be used for field lookup.
      */
     val baseClassRefs: Sequence<TableGenClassRef>
+
+    /**
+     * Returns a set of all base classes (direct and transitive) of this node excluding 'this'.
+     * The set contains a null value if there is at least one base-class that could not be resolved.
+     */
+    val allBaseClasses: Set<TableGenClassStatement?>
+        get() = getProjectContextDependentCache(this) {
+            RecursionManager.doPreventingRecursion(this, true) {
+                baseClassRefs.map {
+                    it.referencedClass
+                }.flatMap {
+                    sequenceOf(it) + it?.allBaseClasses?.asSequence().orEmpty()
+                }.toSet()
+            } ?: emptySet()
+        }
+
+    /**
+     * Returns whether this record is [target] or transitively derives from it. Returns null if the class hierarchy
+     * could not be fully resolved without finding [target]; in that case a derivation through the unresolved class
+     * cannot be ruled out.
+     */
+    fun derivesFrom(target: TableGenFieldScopeNode): Boolean? {
+        // Trivial self case.
+        if (target === this) return true
+
+        // Cannot derive from a non-class.
+        if (target !is TableGenClassStatement) return false
+
+        if (allBaseClasses.contains(target)) return true
+
+        // If null is contained in the set then not all base classes are known.
+        // Depending on the caller we should handle this explicitly.
+        // Return a null sentinel in this case.
+        if (allBaseClasses.contains(null)) return null
+        return false
+    }
 
     val directArgToTemplateArgMapping: Map<TableGenTemplateArgDecl, TableGenValueNode>
         get() = getProjectContextDependentCache(this) {

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/types/TableGenTypes.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/types/TableGenTypes.kt
@@ -7,38 +7,106 @@ import com.intellij.psi.PsiNamedElement
 /**
  * Super class of values representing the TableGen type system.
  */
-sealed class TableGenType
+sealed class TableGenType {
+    /**
+     * Returns whether a value of this type is assignable to a location of the [target] type.
+     *
+     * Returns null whenever the outcome cannot be determined, due to e.g. an erroneous AST or failed reference
+     * resolution.
+     */
+    abstract fun isConvertibleTo(target: TableGenType): Boolean?
+
+    /**
+     * Returns a human-readable representation of this type.
+     */
+    abstract override fun toString(): String
+}
 
 /**
  * 'int' type, which is a 64-bit integer.
  */
-object TableGenIntType : TableGenType()
+object TableGenIntType : TableGenType() {
+    override fun isConvertibleTo(target: TableGenType): Boolean? = when (target) {
+        is TableGenBitType, is TableGenBitsType, is TableGenIntType -> true
+        is TableGenUnknownType -> null
+        else -> false
+    }
+
+    override fun toString() = "int"
+}
 
 /**
  * Single bit type, also used for booleans.
  */
-object TableGenBitType : TableGenType()
+object TableGenBitType : TableGenType() {
+    override fun isConvertibleTo(target: TableGenType): Boolean? = when (target) {
+        is TableGenBitType, is TableGenIntType -> true
+        // A bit is convertible to 'bits<1>'.
+        is TableGenBitsType -> target.numberOfBits?.let { it == 1L }
+        is TableGenUnknownType -> null
+        else -> false
+    }
+
+    override fun toString() = "bit"
+}
 
 /**
  * String type used for string and 'code'.
  */
-object TableGenStringType : TableGenType()
+object TableGenStringType : TableGenType() {
+    override fun isConvertibleTo(target: TableGenType): Boolean? = when (target) {
+        is TableGenStringType -> true
+        is TableGenUnknownType -> null
+        else -> false
+    }
+
+    override fun toString() = "string"
+}
 
 /**
  * Singletonn type representing all DAG instances.
  */
-object TableGenDagType : TableGenType()
+object TableGenDagType : TableGenType() {
+    override fun isConvertibleTo(target: TableGenType): Boolean? = when (target) {
+        is TableGenDagType -> true
+        is TableGenUnknownType -> null
+        else -> false
+    }
+
+    override fun toString() = "dag"
+}
 
 /**
  * Bits type with the given number of bits.
  * [numberOfBits] may be zero if it is unknown, due to e.g. errors in the code.
  */
-data class TableGenBitsType(val numberOfBits: Long?) : TableGenType()
+data class TableGenBitsType(val numberOfBits: Long?) : TableGenType() {
+    override fun isConvertibleTo(target: TableGenType): Boolean? = when (target) {
+        is TableGenBitsType ->
+            if (numberOfBits == null || target.numberOfBits == null) null
+            else numberOfBits == target.numberOfBits
+        // 'bits<1>' is convertible to a single bit.
+        is TableGenBitType -> numberOfBits?.let { it == 1L }
+        is TableGenIntType -> true
+        is TableGenUnknownType -> null
+        else -> false
+    }
+
+    override fun toString() = "bits<${numberOfBits ?: "?"}>"
+}
 
 /**
  * List type containing [elementType] elements.
  */
-data class TableGenListType(val elementType: TableGenType) : TableGenType()
+data class TableGenListType(val elementType: TableGenType) : TableGenType() {
+    override fun isConvertibleTo(target: TableGenType): Boolean? = when (target) {
+        is TableGenListType -> elementType.isConvertibleTo(target.elementType)
+        is TableGenUnknownType -> null
+        else -> false
+    }
+
+    override fun toString() = "list<$elementType>"
+}
 
 /**
  * Type representing either a 'def' or 'class' containing fields.
@@ -78,17 +146,34 @@ class TableGenRecordType private constructor(
     val record: TableGenFieldScopeNode?
         get() = myRecord.invoke()
 
-    override fun equals(other: Any?) = recordName == (other as? TableGenRecordType)?.recordName
+    override fun isConvertibleTo(target: TableGenType): Boolean? {
+        if (target !is TableGenRecordType) return if (target is TableGenUnknownType) null else false
 
-    override fun hashCode() = recordName.hashCode()
+        // Identical class references are trivially convertible, even if resolution fails.
+        if (this === target) return true
+
+        val source = record ?: return null
+        val targetRecord = target.record ?: return null
+        return source.derivesFrom(targetRecord)
+    }
+
+    override fun toString() = recordName
 }
 
 /**
  * Type of the `?` ("undef") value, which is assignable to any field regardless of its type.
  */
-object TableGenUndefType : TableGenType()
+object TableGenUndefType : TableGenType() {
+    override fun isConvertibleTo(target: TableGenType): Boolean = true
+
+    override fun toString() = "?"
+}
 
 /**
  * Type representing an unknown type due to a previous error, but not an error worth reporting itself.
  */
-object TableGenUnknownType : TableGenType()
+object TableGenUnknownType : TableGenType() {
+    override fun isConvertibleTo(target: TableGenType): Boolean? = null
+
+    override fun toString() = "?"
+}

--- a/src/main/resources/messages/MyBundle.properties
+++ b/src/main/resources/messages/MyBundle.properties
@@ -30,6 +30,7 @@ tableGen.syntax.duplicateArgument=Template argument ''{0}'' is assigned more tha
 tableGen.syntax.unknownNamedArgument=Class ''{0}'' has no template argument named ''{1}''
 tableGen.syntax.tooManyArguments=Too many arguments for class ''{0}''; expected at most {1}
 tableGen.syntax.missingArgument=Missing value for required template argument ''{0}''
+tableGen.syntax.argumentTypeMismatch=Value of type ''{0}'' cannot be assigned to template argument ''{1}'' of type ''{2}''
 
 tableGen.syntax.divisionByZero=Division by zero
 

--- a/src/test/kotlin/com/github/zero9178/mlirods/TableGenSyntaxAnnotatorTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/TableGenSyntaxAnnotatorTest.kt
@@ -435,6 +435,94 @@ class TableGenSyntaxAnnotatorTest : BasePlatformTestCase() {
         )
     }
 
+    fun `test argument of matching type is not flagged`() {
+        doResolvingTest(
+            """
+            class C<string a>;
+            def D : C<"hello">;
+        """.trimIndent()
+        )
+    }
+
+    fun `test argument of a convertible type is not flagged`() {
+        // A 'bit' is convertible to an 'int'.
+        doResolvingTest(
+            """
+            class B { bit x = 1; }
+            class C<int a>;
+            def D : C<B<>.x>;
+        """.trimIndent()
+        )
+    }
+
+    fun `test argument of a mismatching type is flagged`() {
+        doResolvingTest(
+            """
+            class C<string a>;
+            def D : C<<error descr="Value of type 'int' cannot be assigned to template argument 'a' of type 'string'">1</error>>;
+        """.trimIndent()
+        )
+    }
+
+    fun `test named argument of a mismatching type is flagged`() {
+        doResolvingTest(
+            """
+            class C<int a = 0>;
+            def D : C<a = <error descr="Value of type 'string' cannot be assigned to template argument 'a' of type 'int'">"oops"</error>>;
+        """.trimIndent()
+        )
+    }
+
+    fun `test undef argument is not flagged`() {
+        doResolvingTest(
+            """
+            class C<int a>;
+            def D : C<?>;
+        """.trimIndent()
+        )
+    }
+
+    fun `test argument of a subclass record type is not flagged`() {
+        doResolvingTest(
+            """
+            class Base;
+            class Derived : Base;
+            class C<Base b>;
+            def D : C<Derived<>>;
+        """.trimIndent()
+        )
+    }
+
+    fun `test argument of an unrelated record type is flagged`() {
+        doResolvingTest(
+            """
+            class Base;
+            class Other;
+            class C<Base b>;
+            def D : C<<error descr="Value of type 'Other' cannot be assigned to template argument 'b' of type 'Base'">Other<></error>>;
+        """.trimIndent()
+        )
+    }
+
+    fun `test list argument with a mismatching element type is flagged`() {
+        doResolvingTest(
+            """
+            class C<list<int> a>;
+            def D : C<<error descr="Value of type 'list<string>' cannot be assigned to template argument 'a' of type 'list<int>'">["a"]</error>>;
+        """.trimIndent()
+        )
+    }
+
+    fun `test empty list argument is not flagged`() {
+        // An empty list has an unknown element type, so its convertibility is indeterminate.
+        doResolvingTest(
+            """
+            class C<list<int> a>;
+            def D : C<[]>;
+        """.trimIndent()
+        )
+    }
+
     /**
      * Highlighting test that additionally installs compile commands so that class references resolve.
      */


### PR DESCRIPTION
Flags a value passed for a template argument when its type cannot be assigned to the argument's declared type, mirroring TableGen's own type convertibility rules. Indeterminate cases (an unknown type, an unknown 'bits<n>' size, or an unresolved record hierarchy) are left unflagged so that a lack of information never turns into a false positive.