### PR TITLE
[TableGen] Compute the type of the remaining value expressions

### DIFF
--- a/src/main/kotlin/com/github/zero9178/mlirods/language/TableGen.bnf
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/TableGen.bnf
@@ -667,10 +667,23 @@ bit_access_value_node ::= value_node '{' range_list '}' {
 }
 private range_list ::= range_piece (',' range_piece)*
 range_piece ::= bit_range
-              | single_bit
-single_bit ::= value_node {extends=range_piece}
+              | single_bit {
+    methods=[
+        toString
+    ]
+    stubClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenRangePieceStub"
+}
+single_bit ::= value_node {
+    extends=range_piece
+    elementTypeClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenSingleBitStubElementType"
+}
 bit_range ::= value_node ('...' | '-') value_node {
     extends=range_piece
+    methods=[
+        start="value_node[0]"
+        end="value_node[1]"
+    ]
+    elementTypeClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenBitRangeStubElementType"
 }
 
 private slice_access_value_node_suffix ::= '[' <<trailing_item_list ']' value_node_follows slice_element>> ']' {
@@ -680,9 +693,24 @@ slice_access_value_node ::= value_node slice_access_value_node_suffix {
     elementTypeClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenSliceAccessValueNodeStubElementType"
 }
 slice_element ::= slice_element_range
-                | single_slice_element
-single_slice_element ::= value_node {extends=slice_element}
-slice_element_range ::= value_node ('...' | '-') value_node {extends=slice_element}
+                | single_slice_element {
+    methods=[
+        toString
+    ]
+    stubClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenSliceElementStub"
+}
+single_slice_element ::= value_node {
+    extends=slice_element
+    elementTypeClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenSingleSliceElementStubElementType"
+}
+slice_element_range ::= value_node ('...' | '-') value_node {
+    extends=slice_element
+    methods=[
+        start="value_node[0]"
+        end="value_node[1]"
+    ]
+    elementTypeClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenSliceElementRangeStubElementType"
+}
 
 private simple_value_node ::= integer_value_node
                           | string_value_node
@@ -832,15 +860,19 @@ private named_identifier_arg_value_item ::= IDENTIFIER '=' value_node {
 // Special Psi node for variable definitions within bang operators.
 bang_operator_definition ::= IDENTIFIER {
     implements=[
+        "com.intellij.psi.PsiElement"
         "com.github.zero9178.mlirods.language.psi.TableGenIdentifierElement"
     ]
     methods=[
         name_identifier="IDENTIFIER"
 
+        toString
         getName
         setName
         getTextOffset
     ]
+    stubClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenIdentifierElementStub"
+    elementTypeClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenBangOperatorDefinitionStubElementType"
 }
 
 foreach_operator_value_node ::= '!foreach' '(' bang_operator_definition ',' value_node ',' value_node ')' {
@@ -933,7 +965,11 @@ cond_clause ::= value_node ':' value_node {
     methods=[
         condition="value_node[0]"
         thenValue="value_node[1]"
+
+        toString
     ]
+    stubClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenCondClauseStub"
+    elementTypeClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenCondClauseStubElementType"
 }
 
 switch_operator_value_node ::= '!switch' '(' value_node ',' <<trailing_item_list_no_comma ')' value_node_follows switch_clause>> ')' {
@@ -949,10 +985,14 @@ switch_clause ::= value_node (':' value_node)? {
     methods=[
         caseKey="value_node[0]"
         caseValue="value_node[1]"
+
+        toString
     ]
     implements=[
         "com.github.zero9178.mlirods.language.psi.impl.TableGenSwitchClauseEx"
     ]
+    stubClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenSwitchClauseStub"
+    elementTypeClass="com.github.zero9178.mlirods.language.stubs.impl.TableGenSwitchClauseStubElementType"
 }
 private switch_clause_recover ::= !(switch_clause_follows)
 private switch_clause_follows ::= ',' | ')'

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenSwitchClauseEx.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenSwitchClauseEx.kt
@@ -1,6 +1,7 @@
 package com.github.zero9178.mlirods.language.psi.impl
 
 import com.github.zero9178.mlirods.language.generated.TableGenTypes
+import com.github.zero9178.mlirods.language.stubs.impl.TableGenSwitchClauseStub
 import com.intellij.psi.PsiElement
 
 /**
@@ -8,10 +9,12 @@ import com.intellij.psi.PsiElement
  */
 interface TableGenSwitchClauseEx : PsiElement {
 
+    val stub: TableGenSwitchClauseStub?
+
     /**
      * Returns whether this clause is a `case : value` pair rather than the trailing default value.
      * A clause with a `:` carries a case value, while the default clause consists of a single value only.
      */
     val hasColon: Boolean
-        get() = node.findChildByType(TableGenTypes.COLON) != null
+        get() = stub?.hasColon ?: (node.findChildByType(TableGenTypes.COLON) != null)
 }

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenValueNodeEx.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenValueNodeEx.kt
@@ -66,7 +66,9 @@ interface TableGenValueNodeEx : PsiElement {
      * Returns the type of this TableGen expression.
      */
     val type: TableGenType
-        get() = accept(TableGenTypeOfValueVisitor)
+        get() = getProjectContextDependentCache(this) {
+            it.accept(TableGenTypeOfValueVisitor)
+        }
 
     /**
      * Performs constant evaluation of this value within the given context.
@@ -94,6 +96,10 @@ interface TableGenValueNodeEx : PsiElement {
  */
 interface TableGenAtomicValue : TableGenValueNodeEx {
     fun evaluateAtomic(): TableGenValue?
+
+    override val type: TableGenType
+        // No need to cache for atomics.
+        get() = accept(TableGenTypeOfValueVisitor)
 
     /**
      * Atomic values do not depend on the [context] and are cheap to compute from their PSI subtree, so [evaluate]

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/TableGenStubElementTypes.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/TableGenStubElementTypes.kt
@@ -147,5 +147,26 @@ interface TableGenStubElementTypes {
 
         @JvmField
         val ARG_VALUE_ITEM = TableGenTypes.ARG_VALUE_ITEM!!
+
+        @JvmField
+        val SINGLE_BIT = TableGenTypes.SINGLE_BIT!!
+
+        @JvmField
+        val BIT_RANGE = TableGenTypes.BIT_RANGE!!
+
+        @JvmField
+        val COND_CLAUSE = TableGenTypes.COND_CLAUSE!!
+
+        @JvmField
+        val SWITCH_CLAUSE = TableGenTypes.SWITCH_CLAUSE!!
+
+        @JvmField
+        val SINGLE_SLICE_ELEMENT = TableGenTypes.SINGLE_SLICE_ELEMENT!!
+
+        @JvmField
+        val SLICE_ELEMENT_RANGE = TableGenTypes.SLICE_ELEMENT_RANGE!!
+
+        @JvmField
+        val BANG_OPERATOR_DEFINITION = TableGenTypes.BANG_OPERATOR_DEFINITION!!
     }
 }

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/TableGenStubFileElementType.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/TableGenStubFileElementType.kt
@@ -29,7 +29,7 @@ class TableGenStubFileElementType :
     }
 
     override fun getStubVersion(): Int {
-        return 24
+        return 27
     }
 
     override fun deserialize(

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/impl/TableGenCondClauseStub.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/impl/TableGenCondClauseStub.kt
@@ -1,0 +1,31 @@
+package com.github.zero9178.mlirods.language.stubs.impl
+
+import com.github.zero9178.mlirods.language.generated.psi.TableGenCondClause
+import com.github.zero9178.mlirods.language.generated.psi.impl.TableGenCondClauseImpl
+import com.intellij.psi.PsiElement
+import com.intellij.psi.stubs.IStubElementType
+import com.intellij.psi.stubs.StubBase
+import com.intellij.psi.stubs.StubElement
+
+/**
+ * Stub interface for [TableGenCondClause].
+ *
+ * A cond clause consists purely of value nodes, all of which are stubbed themselves, and therefore needs to serialize
+ * no data of its own.
+ */
+interface TableGenCondClauseStub : StubElement<TableGenCondClause>
+
+private class TableGenCondClauseStubImpl(
+    parent: StubElement<out PsiElement>?,
+    elementType: IStubElementType<*, *>,
+) : StubBase<TableGenCondClause>(
+    parent, elementType
+), TableGenCondClauseStub
+
+class TableGenCondClauseStubElementType(debugName: String) :
+    TableGenSingletonStubElementType<TableGenCondClauseStub, TableGenCondClause>(
+        debugName, ::TableGenCondClauseImpl, ::TableGenCondClauseStubImpl
+    ) {
+    // The condition and value are stubbed value node children.
+    override fun isAlwaysLeaf(root: StubBase<*>) = false
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/impl/TableGenIdentifierElementStub.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/impl/TableGenIdentifierElementStub.kt
@@ -4,6 +4,7 @@ import com.github.zero9178.mlirods.index.ALL_IDENTIFIERS_INDEX
 import com.github.zero9178.mlirods.index.IDENTIFIER_INDEX
 import com.github.zero9178.mlirods.index.MAY_DERIVE_CLASS_INDEX
 import com.github.zero9178.mlirods.language.generated.psi.TableGenDefStatement
+import com.github.zero9178.mlirods.language.generated.psi.impl.TableGenBangOperatorDefinitionImpl
 import com.github.zero9178.mlirods.language.generated.psi.impl.TableGenDefStatementImpl
 import com.github.zero9178.mlirods.language.generated.psi.impl.TableGenDefvarStatementImpl
 import com.github.zero9178.mlirods.language.generated.psi.impl.TableGenForeachIteratorImpl
@@ -80,6 +81,12 @@ class TableGenForeachIteratorStubElementType(debugName: String) : TableGenAbstra
     debugName,
     ::TableGenForeachIteratorImpl
 )
+
+class TableGenBangOperatorDefinitionStubElementType(debugName: String) :
+    TableGenAbstractIdentifierElementStubElementType(
+        debugName,
+        ::TableGenBangOperatorDefinitionImpl
+    )
 
 sealed interface TableGenDefStatementStub : TableGenIdentifierElementStub {
     val baseClassNames: List<String>

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/impl/TableGenRangePieceStub.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/impl/TableGenRangePieceStub.kt
@@ -1,0 +1,48 @@
+package com.github.zero9178.mlirods.language.stubs.impl
+
+import com.github.zero9178.mlirods.language.generated.psi.TableGenBitRange
+import com.github.zero9178.mlirods.language.generated.psi.TableGenRangePiece
+import com.github.zero9178.mlirods.language.generated.psi.TableGenSingleBit
+import com.github.zero9178.mlirods.language.generated.psi.impl.TableGenBitRangeImpl
+import com.github.zero9178.mlirods.language.generated.psi.impl.TableGenSingleBitImpl
+import com.github.zero9178.mlirods.language.stubs.TableGenStubElementType
+import com.intellij.psi.PsiElement
+import com.intellij.psi.stubs.IStubElementType
+import com.intellij.psi.stubs.StubBase
+import com.intellij.psi.stubs.StubElement
+
+/**
+ * Super type of all stub [TableGenRangePiece] instances.
+ */
+sealed interface TableGenRangePieceStub : StubElement<TableGenRangePiece>
+
+/**
+ * Stub implementation for any range piece. A range piece consists purely of value nodes, all of which are stubbed
+ * themselves, and therefore needs to serialize no data of its own.
+ */
+private class TableGenRangePieceStubImpl(
+    parent: StubElement<out PsiElement>?,
+    elementType: IStubElementType<*, *>,
+) : StubBase<TableGenRangePiece>(
+    parent, elementType
+), TableGenRangePieceStub
+
+sealed class TableGenAbstractRangePieceStubElementType<PsiT : PsiElement>(
+    debugName: String,
+    psiConstructor: (TableGenRangePieceStub, TableGenStubElementType<TableGenRangePieceStub, PsiT>) -> PsiT
+) : TableGenSingletonStubElementType<TableGenRangePieceStub, PsiT>(
+    debugName, psiConstructor, ::TableGenRangePieceStubImpl
+) {
+    // Range pieces contain the value nodes making up the bit indices as children.
+    override fun isAlwaysLeaf(root: StubBase<*>) = false
+}
+
+class TableGenSingleBitStubElementType(debugName: String) :
+    TableGenAbstractRangePieceStubElementType<TableGenSingleBit>(
+        debugName, ::TableGenSingleBitImpl
+    )
+
+class TableGenBitRangeStubElementType(debugName: String) :
+    TableGenAbstractRangePieceStubElementType<TableGenBitRange>(
+        debugName, ::TableGenBitRangeImpl
+    )

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/impl/TableGenSliceElementStub.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/impl/TableGenSliceElementStub.kt
@@ -1,0 +1,48 @@
+package com.github.zero9178.mlirods.language.stubs.impl
+
+import com.github.zero9178.mlirods.language.generated.psi.TableGenSingleSliceElement
+import com.github.zero9178.mlirods.language.generated.psi.TableGenSliceElement
+import com.github.zero9178.mlirods.language.generated.psi.TableGenSliceElementRange
+import com.github.zero9178.mlirods.language.generated.psi.impl.TableGenSingleSliceElementImpl
+import com.github.zero9178.mlirods.language.generated.psi.impl.TableGenSliceElementRangeImpl
+import com.github.zero9178.mlirods.language.stubs.TableGenStubElementType
+import com.intellij.psi.PsiElement
+import com.intellij.psi.stubs.IStubElementType
+import com.intellij.psi.stubs.StubBase
+import com.intellij.psi.stubs.StubElement
+
+/**
+ * Super type of all stub [TableGenSliceElement] instances.
+ */
+sealed interface TableGenSliceElementStub : StubElement<TableGenSliceElement>
+
+/**
+ * Stub implementation for any slice element. A slice element consists purely of value nodes, all of which are stubbed
+ * themselves, and therefore needs to serialize no data of its own.
+ */
+private class TableGenSliceElementStubImpl(
+    parent: StubElement<out PsiElement>?,
+    elementType: IStubElementType<*, *>,
+) : StubBase<TableGenSliceElement>(
+    parent, elementType
+), TableGenSliceElementStub
+
+sealed class TableGenAbstractSliceElementStubElementType<PsiT : PsiElement>(
+    debugName: String,
+    psiConstructor: (TableGenSliceElementStub, TableGenStubElementType<TableGenSliceElementStub, PsiT>) -> PsiT
+) : TableGenSingletonStubElementType<TableGenSliceElementStub, PsiT>(
+    debugName, psiConstructor, ::TableGenSliceElementStubImpl
+) {
+    // Slice elements contain the value nodes making up the indices as children.
+    override fun isAlwaysLeaf(root: StubBase<*>) = false
+}
+
+class TableGenSingleSliceElementStubElementType(debugName: String) :
+    TableGenAbstractSliceElementStubElementType<TableGenSingleSliceElement>(
+        debugName, ::TableGenSingleSliceElementImpl
+    )
+
+class TableGenSliceElementRangeStubElementType(debugName: String) :
+    TableGenAbstractSliceElementStubElementType<TableGenSliceElementRange>(
+        debugName, ::TableGenSliceElementRangeImpl
+    )

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/impl/TableGenSwitchClauseStub.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/impl/TableGenSwitchClauseStub.kt
@@ -1,0 +1,49 @@
+package com.github.zero9178.mlirods.language.stubs.impl
+
+import com.github.zero9178.mlirods.language.generated.psi.TableGenSwitchClause
+import com.github.zero9178.mlirods.language.generated.psi.impl.TableGenSwitchClauseImpl
+import com.github.zero9178.mlirods.language.stubs.TableGenStubElementType
+import com.github.zero9178.mlirods.language.stubs.TableGenStubElementTypes
+import com.intellij.psi.PsiElement
+import com.intellij.psi.stubs.StubBase
+import com.intellij.psi.stubs.StubElement
+import com.intellij.psi.stubs.StubInputStream
+import com.intellij.psi.stubs.StubOutputStream
+
+/**
+ * Stub interface for [TableGenSwitchClause].
+ */
+interface TableGenSwitchClauseStub : StubElement<TableGenSwitchClause> {
+    /**
+     * See [com.github.zero9178.mlirods.language.psi.impl.TableGenSwitchClauseEx.hasColon].
+     * Stored as it is otherwise only derivable from the tokens in the AST.
+     */
+    val hasColon: Boolean
+}
+
+class TableGenSwitchClauseStubElementType(debugName: String) :
+    TableGenStubElementType<TableGenSwitchClauseStub, TableGenSwitchClause>(
+        debugName, ::TableGenSwitchClauseImpl
+    ) {
+
+    override fun createStub(
+        psi: TableGenSwitchClause, parentStub: StubElement<out PsiElement?>?
+    ): TableGenSwitchClauseStub = TableGenSwitchClauseStubImpl(psi.hasColon, parentStub)
+
+    override fun serialize(stub: TableGenSwitchClauseStub, dataStream: StubOutputStream) {
+        dataStream.writeBoolean(stub.hasColon)
+    }
+
+    override fun deserialize(
+        dataStream: StubInputStream, parentStub: StubElement<*>?
+    ): TableGenSwitchClauseStub = TableGenSwitchClauseStubImpl(dataStream.readBoolean(), parentStub)
+
+    // The case key and value are stubbed value node children.
+    override fun isAlwaysLeaf(root: StubBase<*>) = false
+}
+
+private class TableGenSwitchClauseStubImpl(
+    override val hasColon: Boolean, parent: StubElement<out PsiElement>?
+) : StubBase<TableGenSwitchClause>(
+    parent, TableGenStubElementTypes.SWITCH_CLAUSE
+), TableGenSwitchClauseStub

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/types/TableGenTypeOfValueVisitor.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/types/TableGenTypeOfValueVisitor.kt
@@ -22,9 +22,21 @@ import com.github.zero9178.mlirods.language.generated.psi.TableGenSingleSliceEle
 import com.github.zero9178.mlirods.language.generated.psi.TableGenSliceAccessValueNode
 import com.github.zero9178.mlirods.language.generated.psi.TableGenStringValueNode
 import com.github.zero9178.mlirods.language.generated.psi.TableGenTemplateArgDecl
+import com.github.zero9178.mlirods.language.generated.psi.TableGenBangOperatorValueNode
+import com.github.zero9178.mlirods.language.generated.psi.TableGenBitAccessValueNode
+import com.github.zero9178.mlirods.language.generated.psi.TableGenBitRange
+import com.github.zero9178.mlirods.language.generated.psi.TableGenBitsInitValueNode
+import com.github.zero9178.mlirods.language.generated.psi.TableGenCondOperatorValueNode
+import com.github.zero9178.mlirods.language.generated.psi.TableGenSingleBit
+import com.github.zero9178.mlirods.language.generated.psi.TableGenSwitchOperatorValueNode
 import com.github.zero9178.mlirods.language.generated.psi.TableGenUndefValueNode
+import com.github.zero9178.mlirods.language.generated.psi.TableGenValueNode
 import com.github.zero9178.mlirods.language.generated.psi.TableGenVisitor
+import com.github.zero9178.mlirods.language.psi.TableGenBangOperator.*
+import com.github.zero9178.mlirods.language.psi.impl.TableGenEvaluationContext
+import com.github.zero9178.mlirods.language.values.TableGenIntegerValue
 import com.intellij.psi.PsiElement
+import kotlin.math.abs
 
 /**
  * Visitor implementing the type computation logic.
@@ -138,4 +150,106 @@ object TableGenTypeOfValueVisitor : TableGenVisitor<TableGenType>() {
 
     override fun visitCastOperatorValueNode(o: TableGenCastOperatorValueNode) =
         o.typeNode?.toType() ?: TableGenUnknownType
+
+    override fun visitBitsInitValueNode(element: TableGenBitsInitValueNode): TableGenType {
+        var numberOfBits = 0L
+        for (value in element.valueNodeList) {
+            numberOfBits += when (val type = value.type) {
+                // A 'bits<n>' operand contributes all of its bits at once.
+                is TableGenBitsType -> type.numberOfBits ?: return TableGenBitsType(null)
+                // An operand of unknown type may yet be a 'bits<n>' contributing more than one bit, leaving the
+                // total width unknown as well.
+                is TableGenUnknownType -> return TableGenBitsType(null)
+                else -> 1L
+            }
+        }
+        return TableGenBitsType(numberOfBits)
+    }
+
+    override fun visitBitAccessValueNode(element: TableGenBitAccessValueNode): TableGenType {
+        // Selecting bits always yields a 'bits<n>' with one bit per selected bit, regardless of the operand type.
+        var numberOfBits = 0L
+        for (piece in element.rangePieceList) {
+            numberOfBits += when (piece) {
+                is TableGenSingleBit -> 1L
+                is TableGenBitRange -> {
+                    val start = piece.start.constantInteger ?: return TableGenBitsType(null)
+                    val end = piece.end?.constantInteger ?: return TableGenBitsType(null)
+                    // Both bounds are inclusive and may be given in either order.
+                    abs(end - start) + 1
+                }
+
+                else -> return TableGenBitsType(null)
+            }
+        }
+        return TableGenBitsType(numberOfBits)
+    }
+
+    override fun visitCondOperatorValueNode(element: TableGenCondOperatorValueNode) =
+        element.condClauseList.map { it.thenValue?.type ?: TableGenUnknownType }.commonType()
+
+    override fun visitSwitchOperatorValueNode(element: TableGenSwitchOperatorValueNode) =
+        element.switchClauseList.map {
+            // The trailing clause without a ':' is the default value rather than a 'case: value' pair.
+            if (it.hasColon) it.caseValue?.type ?: TableGenUnknownType else it.caseKey.type
+        }.commonType()
+
+    override fun visitBangOperatorValueNode(element: TableGenBangOperatorValueNode): TableGenType {
+        val operands = element.valueNodeList
+        // The optional type argument of e.g. '!getdagarg<int>'.
+        val typeArgument = element.typeNode?.toType()
+        return when (element.operator ?: return TableGenUnknownType) {
+            // Comparisons yield a single bit rather than an 'int'.
+            EQ, NE, LE, LT, GE, GT, MATCH -> TableGenBitType
+
+            ADD, SUB, MUL, DIV, NOT, LOGTWO, AND, OR, XOR, SHL, SRA, SRL, SIZE, EMPTY, FIND, ISA, EXISTS, INITIALIZED ->
+                TableGenIntType
+
+            REPR, TOLOWER, TOUPPER, STRCONCAT, INTERLEAVE, SUBSTR, GETDAGOPNAME, GETDAGNAME -> TableGenStringType
+
+            DAG, CON, SETDAGOP, SETDAGOPNAME, SETDAGARG, SETDAGNAME -> TableGenDagType
+
+            RANGE -> TableGenListType(TableGenIntType)
+
+            INSTANCES -> TableGenListType(typeArgument ?: TableGenUnknownType)
+
+            // '!getdagop' without a type argument yields a record of any class, which is not modelled as a type.
+            GETDAGOP, GETDAGARG -> typeArgument ?: TableGenUnknownType
+
+            IF -> commonType(
+                operands.getOrNull(1)?.type ?: TableGenUnknownType,
+                operands.getOrNull(2)?.type ?: TableGenUnknownType,
+            )
+
+            // '!subst' yields whatever its third operand is.
+            SUBST -> operands.getOrNull(2)?.type ?: TableGenUnknownType
+
+            // '!head' yields the element type of its operand, while '!tail' yields the list itself.
+            HEAD -> (operands.firstOrNull()?.type as? TableGenListType)?.elementType ?: TableGenUnknownType
+            TAIL -> operands.firstOrNull()?.type as? TableGenListType ?: TableGenUnknownType
+
+            LISTSPLAT -> TableGenListType(operands.firstOrNull()?.type ?: TableGenUnknownType)
+
+            // Both yield a list that all operand lists are compatible with.
+            LISTCONCAT, LISTREMOVE -> operands.map { it.type }.commonType() as? TableGenListType
+                ?: TableGenUnknownType
+
+            LISTFLATTEN -> {
+                val elementType = (operands.firstOrNull()?.type as? TableGenListType)?.elementType
+                    ?: return TableGenUnknownType
+                // 'list<list<x>>' is flattened to 'list<x>', while a list of non-lists is left as-is.
+                elementType as? TableGenListType ?: TableGenListType(elementType)
+            }
+        }
+    }
 }
+
+/**
+ * Returns the value of this node if it folds to an integer or null otherwise.
+ *
+ * A bit range bound does not have to be an integer literal, it only has to fold to an integer. TableGen folds it
+ * without a current record, so a global 'defvar' folds while a template argument or field never does, even if it is an
+ * integer. Evaluating in the null context yields exactly that behaviour.
+ */
+private val TableGenValueNode.constantInteger: Long?
+    get() = (evaluate(TableGenEvaluationContext()) as? TableGenIntegerValue)?.value

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/types/TableGenTypes.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/types/TableGenTypes.kt
@@ -177,3 +177,37 @@ object TableGenUnknownType : TableGenType() {
 
     override fun toString() = "?"
 }
+
+/**
+ * Returns the type that values of both [t1] and [t2] can be used as, as is required by operators yielding one of
+ * multiple values (e.g. '!if' or '!cond').
+ *
+ * [TableGenUndefType] adopts the type of the other side, as a '?' operand is compatible with any type.
+ * [TableGenUnknownType] is returned if the two types are inconsistent, mirroring that TableGen rejects such programs;
+ * reporting them is up to the caller.
+ */
+fun commonType(t1: TableGenType, t2: TableGenType): TableGenType {
+    // Both '?' and an unknown type carry no information, making the other side the best guess available.
+    if (t1 is TableGenUndefType || t1 is TableGenUnknownType) return t2
+    if (t2 is TableGenUndefType || t2 is TableGenUnknownType) return t1
+
+    if (t1 == t2) return t1
+    if (t1.isConvertibleTo(t2) == true) return t2
+    if (t2.isConvertibleTo(t1) == true) return t1
+
+    // Two lists have a common list type if their element types do.
+    if (t1 is TableGenListType && t2 is TableGenListType) {
+        return TableGenListType(commonType(t1.elementType, t2.elementType))
+    }
+
+    // TODO: Two record types where neither derives from the other still have the set of classes that both derive from
+    //  as their common type. Representing this requires a record type constrained by a set of classes rather than one
+    //  naming a single record, so an unknown type is returned for now.
+    return TableGenUnknownType
+}
+
+/**
+ * Returns the type that values of all types in this collection can be used as. See [commonType].
+ */
+fun Iterable<TableGenType>.commonType(): TableGenType =
+    reduceOrNull(::commonType) ?: TableGenUnknownType

--- a/src/test/kotlin/com/github/zero9178/mlirods/TypeComputationTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/TypeComputationTest.kt
@@ -2,11 +2,7 @@ package com.github.zero9178.mlirods
 
 
 import com.github.zero9178.mlirods.language.generated.psi.TableGenDefvarStatement
-import com.github.zero9178.mlirods.language.types.TableGenIntType
-import com.github.zero9178.mlirods.language.types.TableGenListType
-import com.github.zero9178.mlirods.language.types.TableGenStringType
-import com.github.zero9178.mlirods.language.types.TableGenType
-import com.github.zero9178.mlirods.language.types.TableGenUndefType
+import com.github.zero9178.mlirods.language.types.*
 import com.intellij.psi.util.parentOfType
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 
@@ -117,9 +113,315 @@ class TypeComputationTest : BasePlatformTestCase() {
     }
 
 
-    fun doTest(source: String, expectedType: TableGenType) {
+    fun `test bits init`() {
+        doTest(
+            """
+            defvar <caret>v = {1, 0, 1};
+        """.trimIndent(), TableGenBitsType(3)
+        )
+    }
+
+    fun `test bits init with bits operand`() {
+        doTest(
+            """
+            class Foo {
+                bits<4> b;
+            }
+            def Bar : Foo;
+            defvar <caret>v = {Bar.b, 1};
+        """.trimIndent(), TableGenBitsType(5)
+        )
+    }
+
+    fun `test bits init with unknown operand`() {
+        doTest(
+            """
+            defvar <caret>v = {undefined, 1};
+        """.trimIndent(), TableGenBitsType(null)
+        )
+    }
+
+    fun `test bit access single bit`() {
+        doTest(
+            """
+            defvar b = {1, 0, 1, 0};
+            defvar <caret>v = b{2};
+        """.trimIndent(), TableGenBitsType(1)
+        )
+    }
+
+    fun `test bit access range`() {
+        doTest(
+            """
+            defvar b = {1, 0, 1, 0};
+            defvar <caret>v = b{3-0};
+        """.trimIndent(), TableGenBitsType(4)
+        )
+    }
+
+    fun `test bit access multiple pieces`() {
+        doTest(
+            """
+            defvar b = {1, 0, 1, 0};
+            defvar <caret>v = b{3...2, 0};
+        """.trimIndent(), TableGenBitsType(3)
+        )
+    }
+
+    /**
+     * A single bit piece selects exactly one bit, regardless of whether the index itself can be determined.
+     */
+    fun `test bit access non constant single bit`() {
+        doTest(
+            """
+            defvar b = {1, 0, 1, 0};
+            defvar <caret>v = b{undefined};
+        """.trimIndent(), TableGenBitsType(1)
+        )
+    }
+
+    fun `test bit access non constant range`() {
+        doTest(
+            """
+            defvar b = {1, 0, 1, 0};
+            defvar <caret>v = b{undefined...0};
+        """.trimIndent(), TableGenBitsType(null)
+        )
+    }
+
+    /**
+     * Range bounds need not be integer literals, they only have to fold to an integer. TableGen parses them with no
+     * current record, so a global 'defvar' folds while template arguments and fields never do.
+     */
+    fun `test bit access range folds constant bounds`() {
+        doTest(
+            """
+            defvar b = {1, 0, 1, 0};
+            defvar i = 3;
+            defvar <caret>v = b{i-0};
+        """.trimIndent(), TableGenBitsType(4)
+        )
+    }
+
+    fun `test cond`() {
+        doTest(
+            """
+            defvar <caret>v = !cond(true: 1, false: 2);
+        """.trimIndent(), TableGenIntType
+        )
+    }
+
+    fun `test cond resolves to common type`() {
+        doTest(
+            """
+            defvar <caret>v = !cond(true: [1], false: []);
+        """.trimIndent(), TableGenListType(TableGenIntType)
+        )
+    }
+
+    fun `test cond ignores undef`() {
+        doTest(
+            """
+            defvar <caret>v = !cond(true: ?, false: "a");
+        """.trimIndent(), TableGenStringType
+        )
+    }
+
+    fun `test switch`() {
+        doTest(
+            """
+            defvar <caret>v = !switch(1, 1: "a", "b");
+        """.trimIndent(), TableGenStringType
+        )
+    }
+
+    fun `test switch default only`() {
+        doTest(
+            """
+            defvar <caret>v = !switch(1, 1: 2, 3);
+        """.trimIndent(), TableGenIntType
+        )
+    }
+
+    fun `test bang operator comparison yields bit`() {
+        doTest(
+            """
+            defvar <caret>v = !eq(1, 2);
+        """.trimIndent(), TableGenBitType
+        )
+    }
+
+    fun `test bang operator arithmetic`() {
+        doTest(
+            """
+            defvar <caret>v = !add(1, 2, 3);
+        """.trimIndent(), TableGenIntType
+        )
+    }
+
+    fun `test bang operator strconcat`() {
+        doTest(
+            """
+            defvar <caret>v = !strconcat("a", "b");
+        """.trimIndent(), TableGenStringType
+        )
+    }
+
+    fun `test bang operator size`() {
+        doTest(
+            """
+            defvar <caret>v = !size([1, 2]);
+        """.trimIndent(), TableGenIntType
+        )
+    }
+
+    fun `test bang operator head`() {
+        doTest(
+            """
+            defvar <caret>v = !head([[1]]);
+        """.trimIndent(), TableGenListType(TableGenIntType)
+        )
+    }
+
+    fun `test bang operator tail`() {
+        doTest(
+            """
+            defvar <caret>v = !tail([1]);
+        """.trimIndent(), TableGenListType(TableGenIntType)
+        )
+    }
+
+    fun `test bang operator listsplat`() {
+        doTest(
+            """
+            defvar <caret>v = !listsplat("a", 3);
+        """.trimIndent(), TableGenListType(TableGenStringType)
+        )
+    }
+
+    fun `test bang operator listflatten`() {
+        doTest(
+            """
+            defvar <caret>v = !listflatten([[1], [2]]);
+        """.trimIndent(), TableGenListType(TableGenIntType)
+        )
+    }
+
+    fun `test bang operator listflatten of non lists`() {
+        doTest(
+            """
+            defvar <caret>v = !listflatten([1, 2]);
+        """.trimIndent(), TableGenListType(TableGenIntType)
+        )
+    }
+
+    fun `test bang operator listconcat`() {
+        doTest(
+            """
+            defvar <caret>v = !listconcat([1], []);
+        """.trimIndent(), TableGenListType(TableGenIntType)
+        )
+    }
+
+    fun `test bang operator range`() {
+        doTest(
+            """
+            defvar <caret>v = !range(4);
+        """.trimIndent(), TableGenListType(TableGenIntType)
+        )
+    }
+
+    fun `test bang operator if`() {
+        doTest(
+            """
+            defvar <caret>v = !if(true, "a", "b");
+        """.trimIndent(), TableGenStringType
+        )
+    }
+
+    fun `test bang operator if resolves to common type`() {
+        doTest(
+            """
+            defvar <caret>v = !if(true, [1], []);
+        """.trimIndent(), TableGenListType(TableGenIntType)
+        )
+    }
+
+    fun `test bang operator subst`() {
+        doTest(
+            """
+            defvar <caret>v = !subst("a", "b", "c");
+        """.trimIndent(), TableGenStringType
+        )
+    }
+
+    fun `test bang operator con yields dag`() {
+        doTest(
+            """
+            def op;
+            defvar <caret>v = !con((op 1), (op 2));
+        """.trimIndent(), TableGenDagType
+        )
+    }
+
+    fun `test bang operator getdagarg uses type argument`() {
+        doTest(
+            """
+            def op;
+            defvar <caret>v = !getdagarg<int>((op 1), 0);
+        """.trimIndent(), TableGenIntType
+        )
+    }
+
+    fun `test bang operator isa yields int`() {
+        doTest(
+            """
+            class Foo;
+            defvar <caret>v = !isa<Foo>(1);
+        """.trimIndent(), TableGenIntType
+        )
+    }
+
+    fun `test bang operator instances yields list of type argument`() {
+        doTestString(
+            """
+            class Foo;
+            defvar <caret>v = !instances<Foo>();
+        """.trimIndent(), "list<Foo>"
+        )
+    }
+
+    fun `test bang operator getdagop without type argument`() {
+        doTest(
+            """
+            def op;
+            defvar <caret>v = !getdagop((op 1));
+        """.trimIndent(), TableGenUnknownType
+        )
+    }
+
+    fun `test unknown bang operator`() {
+        doTest(
+            """
+            defvar <caret>v = !nonsense(1);
+        """.trimIndent(), TableGenUnknownType
+        )
+    }
+
+    private fun typeAtCaret(source: String): TableGenType? {
         myFixture.configureByText("test.td", source)
         val statement = requireNotNull(myFixture.elementAtCaret.parentOfType<TableGenDefvarStatement>(withSelf = true))
-        assertEquals(expectedType, statement.valueNode?.type)
+        return statement.valueNode?.type
+    }
+
+    fun doTest(source: String, expectedType: TableGenType) {
+        assertEquals(expectedType, typeAtCaret(source))
+    }
+
+    /**
+     * Variant of [doTest] comparing the rendered type, for types such as record types which have no value equality.
+     */
+    fun doTestString(source: String, expectedType: String) {
+        assertEquals(expectedType, typeAtCaret(source).toString())
     }
 }


### PR DESCRIPTION
Bit initializers, bit access, '!cond', '!switch' and the type-carrying bang operators previously had no type of their own, leaving anything built on top of them untyped. Their types follow from their operands: a bit initializer or bit selection is as wide as the bits it collects, while an operator yielding one of several values takes the type all of its candidate values can be used as. The latter is what the new 'commonType' expresses, with '?' and unknown operands deferring to the other side so that missing information never contradicts what is known.

Computing this means reading the operands, which would force a parse of every file involved were it done over the PSI tree. The clause, range piece, slice element and bang operator iterator constructs the computation traverses are therefore stubbed as well, completing stub coverage of the value expression tree. As the computation is now recursive, non-atomic values cache their type; atomics stay uncached since they are cheap to recompute from their own subtree.