### PR TITLE
Let users report plugin exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Added an editor banner warning that a file's includes and references cannot be resolved when the file is not reachable from any file with compile commands.
 - `multiclass` statements now introduce a scope, so that references within them resolve to the multiclass' template arguments and to statements declared inside it.
 - Added an error for a template argument whose value is of a type that is not assignable to the argument's declared type.
+- Exceptions originating from the plugin can now be reported to the plugin's vendor from the IDE's error dialog.
 
 ### Changed
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -129,6 +129,7 @@
                 implementation="com.github.zero9178.mlirods.language.TableGenNoContextNotificationProvider"/>
         <postStartupActivity
                 implementation="com.github.zero9178.mlirods.model.TableGenWorkspaceModelStartup"/>
+        <errorHandler implementation="com.intellij.diagnostic.JetBrainsMarketplaceErrorReportSubmitter"/>
     </extensions>
 
     <extensions defaultExtensionNs="com.intellij.platform.lsp">


### PR DESCRIPTION
Exceptions thrown by the plugin so far only ended up in the user's local log, leaving no way for them to report to us automatically short of the user manually filing an issue with a copied stacktrace.

Registering the marketplace error report submitter makes the IDE's error dialog offer to send the report to JetBrains Marketplace's exception analyzer instead. The platform owns the consent notice and the transport, so no stacktrace leaves the machine without the user seeing it first.