### PR TITLE
[TableGen] Search for usages of a definition in all TableGen files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 - Binary literals such as `0b1010` are now `bits<n>` values with one bit per digit written rather than integers, making e.g. `{ 0b1010, 0b0101 }` a `bits<8>` rather than a `bits<2>`.
 - Binary literals are no longer accepted where TableGen requires an integer, such as the width of a `bits<n>` type.
+- Usages of a definition are now highlighted and found in every TableGen file, rather than only in those belonging to the same module as the definition.
 
 ## [0.14.0] - 2026-06-25
 

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/TableGenUseScopeEnlarger.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/TableGenUseScopeEnlarger.kt
@@ -1,0 +1,32 @@
+package com.github.zero9178.mlirods.language
+
+import com.github.zero9178.mlirods.language.generated.psi.TableGenClassStatement
+import com.github.zero9178.mlirods.language.generated.psi.TableGenDefineDirective
+import com.github.zero9178.mlirods.language.psi.TableGenIdentifierElement
+import com.intellij.psi.PsiElement
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.SearchScope
+import com.intellij.psi.search.UseScopeEnlarger
+
+/**
+ * Widens the use scope of TableGen definitions to all TableGen files.
+ *
+ * A definition is referenced by every file transitively including it, which is unrelated to the module a file belongs
+ * to. The default use scope is derived from that module, making it too narrow: the includer may live in a different
+ * module than the definition, e.g. the synthetic module contributed by
+ * [com.github.zero9178.mlirods.model.TableGenWorkspaceModelService] for TableGen files outside the project's content.
+ * Searches such as the identifier highlighting under the caret intersect with the use scope and would otherwise find no
+ * references, even though resolution succeeds.
+ *
+ * Restricting to TableGen files keeps the scope as small as still sound, as only they can reference a definition.
+ */
+internal class TableGenUseScopeEnlarger : UseScopeEnlarger() {
+    override fun getAdditionalUseScope(element: PsiElement): SearchScope? = when (element) {
+        is TableGenClassStatement, is TableGenIdentifierElement, is TableGenDefineDirective ->
+            GlobalSearchScope.getScopeRestrictedByFileTypes(
+                GlobalSearchScope.allScope(element.project), TableGenFileType.INSTANCE
+            )
+
+        else -> null
+    }
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/model/TableGenWorkspaceModelService.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/model/TableGenWorkspaceModelService.kt
@@ -106,8 +106,9 @@ class TableGenWorkspaceModelService(private val project: Project, cs: CoroutineS
         val fileIndex = ProjectFileIndex.getInstance(project)
         val ownFiles = readAction {
             graphService.getFilesWithContext().filter { file ->
-                val owner = fileIndex.getModuleForFile(file)
-                owner == null || owner.name == MODULE_NAME
+                fileIndex.getModulesForFile(file, true).all {
+                    it.name == MODULE_NAME
+                }
             }
         }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -89,6 +89,7 @@
         <iconProvider implementation="com.github.zero9178.mlirods.language.TableGenIconProvider"/>
         <lang.findUsagesProvider language="TableGen"
                                  implementationClass="com.github.zero9178.mlirods.language.TableGenFindUsageProvider"/>
+        <useScopeEnlarger implementation="com.github.zero9178.mlirods.language.TableGenUseScopeEnlarger"/>
         <codeInsight.parameterInfo language="TableGen"
                                    implementationClass="com.github.zero9178.mlirods.language.TableGenParameterInfoHandler"/>
         <codeInsight.lineMarkerProvider language="TableGen"


### PR DESCRIPTION
Which file references a definition follows from the include graph alone: every file transitively including the definition may use it, regardless of which module either of them belongs to. The use scope the platform derives from a definition's module is therefore too narrow, and the searches intersecting with it, such as the highlighting of the identifier under the caret, come up empty even though resolution succeeds. Files outside the project's content are especially affected, as the module contributed for them is by construction a different one than that of any file in the project.

Widen the use scope of every definition to all TableGen files, which is the smallest scope that stays sound while remaining independent of the module layout. Along with it, stop the contributed module from claiming files that another module already owns, so that a file is never ambiguously part of two modules.