### PR TITLE
[TableGen] Never resolve an identifier to a def inside a multiclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Binary literals are no longer accepted where TableGen requires an integer, such as the width of a `bits<n>` type.
 - Usages of a definition are now highlighted and found in every TableGen file, rather than only in those belonging to the same module as the definition.
 - A class that is forward declared before being defined, as LLVM's `Instruction` is, is now recognized as one class rather than two. Records deriving from its definition are therefore no longer reported as having the wrong type where the declaration is used as a template argument type or base class.
+- References within a `multiclass` no longer resolve to a `def` inside that same `multiclass`. Such a `def` only exists once a `defm` instantiates the multiclass.
 
 ## [0.14.0] - 2026-06-25
 

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenMulticlassStatementMixin.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenMulticlassStatementMixin.kt
@@ -1,5 +1,6 @@
 package com.github.zero9178.mlirods.language.psi.impl
 
+import com.github.zero9178.mlirods.language.generated.psi.TableGenDefStatement
 import com.github.zero9178.mlirods.language.generated.psi.TableGenMulticlassStatement
 import com.github.zero9178.mlirods.language.psi.TableGenIdentifierElement
 import com.github.zero9178.mlirods.language.psi.TableGenIdentifierScopeNode
@@ -20,7 +21,9 @@ abstract class TableGenMulticlassStatementMixin : StubBasedPsiElementBase<TableG
     override fun toString(): String = TableGenPsiImplUtil.toString(this)
 
     private var myDirectIdMap = resettableLazy {
-        stubbedChildren<TableGenIdentifierElement>().mapNotNull {
+        // 'def's within a multiclass are only instantiated by 'defm's with 'NAME' prepended to their names.
+        // They can therefore never be found by identifier lookup, only via '!cast'.
+        stubbedChildren<TableGenIdentifierElement>().filter { it !is TableGenDefStatement }.mapNotNull {
             val name = it.name ?: return@mapNotNull null
             name to it
         }.groupBy({

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/TableGenStubFileElementType.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/TableGenStubFileElementType.kt
@@ -29,7 +29,7 @@ class TableGenStubFileElementType :
     }
 
     override fun getStubVersion(): Int {
-        return 28
+        return 29
     }
 
     override fun deserialize(

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/impl/TableGenIdentifierElementStub.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/stubs/impl/TableGenIdentifierElementStub.kt
@@ -11,6 +11,7 @@ import com.github.zero9178.mlirods.language.generated.psi.impl.TableGenForeachIt
 import com.github.zero9178.mlirods.language.psi.TableGenIdentifierElement
 import com.github.zero9178.mlirods.language.stubs.TableGenFileStub
 import com.github.zero9178.mlirods.language.stubs.TableGenStubElementType
+import com.github.zero9178.mlirods.language.stubs.TableGenStubElementTypes
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.*
 
@@ -130,10 +131,17 @@ class TableGenDefStatementStubElementType(debugName: String) :
         stub: TableGenDefStatementStub,
         sink: IndexSink
     ) {
-        stub.name?.let {
-            sink.occurrence(IDENTIFIER_INDEX, it)
+        // 'def's within a multiclass are only instantiated by 'defm's with 'NAME' prepended to their names.
+        // They can therefore never be found by identifier lookup under their local name.
+        val withinMulticlass = generateSequence(stub.parentStub) { it.parentStub }.any {
+            it.elementType === TableGenStubElementTypes.MULTICLASS_STATEMENT
         }
-        sink.occurrence(ALL_IDENTIFIERS_INDEX, 0)
+        if (!withinMulticlass) {
+            stub.name?.let {
+                sink.occurrence(IDENTIFIER_INDEX, it)
+            }
+            sink.occurrence(ALL_IDENTIFIERS_INDEX, 0)
+        }
         stub.baseClassNames.forEach {
             sink.occurrence(MAY_DERIVE_CLASS_INDEX, it)
         }

--- a/src/test/kotlin/com/github/zero9178/mlirods/ReferenceTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/ReferenceTest.kt
@@ -363,6 +363,62 @@ class ReferenceTest : BasePlatformTestCase() {
         assertNotNull(element.parentOfType<TableGenMulticlassStatement>())
     }
 
+    fun `test multiclass def not referenceable`() {
+        val mainVF = myFixture.createFile(
+            "test.td", """
+            multiclass M {
+                def foo;
+                def bar { int x = <caret>foo; }
+            }
+        """.trimIndent()
+        )
+        installCompileCommands(
+            project, mapOf(
+                mainVF to IncludePaths(emptyList())
+            )
+        )
+
+        myFixture.configureFromExistingVirtualFile(mainVF)
+        assertNull(myFixture.file.findReferenceAt(myFixture.caretOffset)?.resolve())
+    }
+
+    fun `test multiclass def does not shadow global def`() {
+        val element = doTestInline<TableGenDefStatement>(
+            """
+            def foo;
+
+            multiclass M {
+                def foo;
+                def bar { int x = <caret>foo; }
+            }
+        """.trimIndent()
+        )
+        assertEquals("foo", element.name)
+        assertNull(element.parentOfType<TableGenMulticlassStatement>())
+    }
+
+    fun `test multiclass def not in index`() {
+        val mainVF = myFixture.createFile(
+            "test.td", """
+            multiclass M {
+                foreach i = [0] in {
+                    def foo;
+                }
+            }
+
+            defvar v = <caret>foo;
+        """.trimIndent()
+        )
+        installCompileCommands(
+            project, mapOf(
+                mainVF to IncludePaths(emptyList())
+            )
+        )
+
+        myFixture.configureFromExistingVirtualFile(mainVF)
+        assertNull(myFixture.file.findReferenceAt(myFixture.caretOffset)?.resolve())
+    }
+
     fun `test append let`() {
         val iter = doTestInline<TableGenFieldBodyItem>(
             """


### PR DESCRIPTION
A def within a multiclass only comes into existence once a 'defm' instantiates the multiclass, and it does so under the instantiation's 'NAME' prepended to its own name. An identifier within a multiclass can therefore never refer to such a def: TableGen resolves it against template arguments, local variables and global records only, making a '!cast' on the computed name the sole way to reach a sibling def. The plugin nevertheless offered these defs to identifier lookup, so a reference within a multiclass resolved to a sibling def, shadowing a global record of the same name that TableGen would actually pick.

Exclude defs from the scope a multiclass contributes to identifier lookup and from the identifier indexes whenever a def is nested within a multiclass, no matter how deeply. Local variables and template arguments remain visible, matching the lookup TableGen itself performs within a multiclass body.