### PR TITLE
[Model] Contribute content roots without awaiting a workspace change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Files reachable from the compile commands are now indexed right after opening a project, rather than only once a module's content roots happened to change afterwards. Their classes, defs and other definitions were previously not found by references, completion or find usages until e.g. CMake reconfigured.
+
 ## [0.15.0] - 2026-08-07
 
 ### Added

--- a/src/main/kotlin/com/github/zero9178/mlirods/model/TableGenWorkspaceModelService.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/model/TableGenWorkspaceModelService.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import org.jetbrains.annotations.TestOnly
 
@@ -70,7 +71,12 @@ class TableGenWorkspaceModelService(private val project: Project, cs: CoroutineS
             //  - the set of files-with-context changed (contextGeneration), and
             //  - another module's roots changed, e.g. CMake reconfigured. updateContentRoots drops files another
             //    module already owns, so that decision goes stale when those modules' content roots move.
-            val foreignRootChanges = workspaceModel.eventLog.filter { it.hasForeignRootChange() }
+            // The event log only reports changes made from here on, so seed it: every module may already have been
+            // loaded by the time this service starts, in which case there is no further change to wait for.
+            val foreignRootChanges = workspaceModel.eventLog
+                .filter { it.hasForeignRootChange() }
+                .map { }
+                .onStart { emit(Unit) }
             graphService.graphGeneration.combine(foreignRootChanges) { gen, _ -> gen }.collectLatest {
                 val startTime = System.nanoTime()
                 updateContentRoots(graphService)

--- a/src/test/kotlin/com/github/zero9178/mlirods/WorkspaceModelTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/WorkspaceModelTest.kt
@@ -6,6 +6,8 @@ import com.github.zero9178.mlirods.model.IncludePaths
 import com.github.zero9178.mlirods.model.TableGenEntitySource
 import com.github.zero9178.mlirods.model.TableGenIncludeGraphService
 import com.github.zero9178.mlirods.model.TableGenWorkspaceModelService
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.application.impl.TestOnlyThreading
 import com.intellij.openapi.components.service
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.util.io.FileUtil
@@ -18,7 +20,16 @@ import com.intellij.psi.stubs.StubIndex
 import com.intellij.testFramework.HeavyPlatformTestCase
 import com.intellij.testFramework.IndexingTestUtil
 import com.intellij.testFramework.PlatformTestUtil
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import java.io.File
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Name of the module the test contributes with [TableGenEntitySource], i.e. one the service considers its own.
+ */
+private const val OUR_MODULE_NAME = "Test TableGen Module"
 
 /**
  * Tests for [TableGenWorkspaceModelService]: every TableGen file that has a context – a compile-command root or a file
@@ -101,6 +112,39 @@ class WorkspaceModelTest : HeavyPlatformTestCase() {
         assertContainsElements(urls, rootB.url)
         assertDoesntContain(urls, rootA.url)
         assertDoesntContain(urls, included.url)
+    }
+
+    fun `test content roots are contributed without any workspace change following`() {
+        val (includeDir, included) = createExternalDir("included.td", "class Included;")
+        val (_, root) = createExternalDir("root.td", "include \"included.td\"")
+
+        // Leave a change of our own as the last one in the workspace model before the service starts. The service
+        // ignores its own changes, so this stands in for a project whose modules have all been loaded by the time it
+        // starts: nothing it reacts to is left to arrive, and it must contribute content roots regardless.
+        val workspaceModel = WorkspaceModel.getInstance(project)
+        WriteAction.runAndWait<Throwable> {
+            workspaceModel.updateProjectModel("Add a module of our own") { storage ->
+                storage.addEntity(ModuleEntity(OUR_MODULE_NAME, emptyList(), TableGenEntitySource))
+            }
+        }
+        // The service subscribes to the event log, which replays the last change to every new subscriber. Only once
+        // ours is that change does the test cover a service that is not handed a change it reacts to.
+        TestOnlyThreading.releaseTheAcquiredWriteIntentLockThenExecuteActionAndTakeWriteIntentLockBack {
+            runBlocking {
+                withTimeout(10.seconds) {
+                    workspaceModel.eventLog.first { change ->
+                        change.getChanges(ModuleEntity::class.java).any {
+                            (it.newEntity ?: it.oldEntity)?.name == OUR_MODULE_NAME
+                        }
+                    }
+                }
+            }
+        }
+
+        val update = workspaceUpdater()
+        update(mapOf(root to IncludePaths(listOf(includeDir))))
+
+        assertContainsElements(ourContentRootUrls(), root.url, included.url)
     }
 
     fun `test class in included file is indexed and in allScope`() {


### PR DESCRIPTION
The workspace service derives its content roots from two signals: the include graph's generation and any change to a module's roots, as the latter may shift which files another module already owns. Combining the two means the service only ever acts once both have produced a value, yet a project whose modules have all been loaded by the time the service starts has no such change left to deliver. The event log only replays a single past change, and one of our own does not qualify, so the files reachable from the compile commands stayed uncontributed until something unrelated moved another module's roots, such as CMake reconfiguring.

Seed the change signal so the first value comes from the include graph alone, leaving foreign root changes to only ever trigger a re-derivation.