### PR TITLE
[TableGen] Add completion for bang operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,16 @@
 
 ## [Unreleased]
 
+### Added
+
+- Typing `!` now offers completion for every bang operator known to the plugin, inserting the parentheses of its argument list and, in the case of `!cast`, also the angle brackets of its type argument. Delimiters that have already been written are reused and, if left unclosed, completed to a balanced pair, and the Tab key moves the caret out of an inserted pair — for `!cast`, from the type argument into the parentheses and finally behind them.
+- Completing a class or the `list` and `bits` types now also enters angled brackets that were already written but are still empty, and the Tab key moves the caret out of the brackets after the content has been written.
+
 ### Fixed
 
 - Files reachable from the compile commands are now indexed right after opening a project, rather than only once a module's content roots happened to change afterwards. Their classes, defs and other definitions were previously not found by references, completion or find usages until e.g. CMake reconfigured.
+- Completing `list` or `bits` in front of already written angled brackets no longer inserts a second empty pair.
+- Selecting a class, `list` or `bits` completion by typing `<` no longer types that `<` into the angled brackets inserted by the completion.
 
 ## [0.15.0] - 2026-08-07
 

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/completion/TableGenBangOperatorCompletionContributor.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/completion/TableGenBangOperatorCompletionContributor.kt
@@ -1,0 +1,109 @@
+package com.github.zero9178.mlirods.language.completion
+
+import com.github.zero9178.mlirods.language.generated.TableGenTypes.BANG_OPERATOR
+import com.github.zero9178.mlirods.language.generated.psi.TableGenBangOperatorValueNode
+import com.github.zero9178.mlirods.language.psi.TableGenBangOperator
+import com.intellij.codeInsight.completion.CompletionContributor
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionProvider
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.codeInsight.completion.InsertHandler
+import com.intellij.codeInsight.completion.InsertionContext
+import com.intellij.codeInsight.completion.util.ParenthesesInsertHandler
+import com.intellij.codeInsight.editorActions.TabOutScopesTracker
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.openapi.project.DumbAware
+import com.intellij.patterns.PlatformPatterns.psiElement
+import com.intellij.psi.util.startOffset
+import com.intellij.util.ProcessingContext
+
+/**
+ * Inserts the '<type>' argument and parentheses '!cast' requires after the operator, following the conventions of
+ * [ParenthesesInsertHandler]: delimiters the user has already written are reused, a missing closing delimiter of a pair
+ * the user started is inserted such that the operator's delimiters are always balanced afterwards, and the caret is
+ * placed in the leftmost delimiter pair the user has yet to fill in. [TabOutScopesTracker] is told about any empty pair
+ * so that the user can tab from the type argument into the parentheses and out of them.
+ */
+private object TypeAndArgumentsInsertHandler : InsertHandler<LookupElement> {
+    override fun handleInsert(
+        context: InsertionContext,
+        item: LookupElement
+    ) {
+        val editor = context.editor
+        val document = editor.document
+
+        // Insert no delimiters if the user has turned that off, unless the completion was selected by typing the
+        // leading one.
+        if (context.completionChar != '<' && !editor.settings.isInsertParenthesesAutomatically) return
+        // A delimiter the completion was selected with is established by this handler already and must not be typed
+        // into the pair the caret is placed in.
+        if (context.completionChar == '<' || context.completionChar == '(') context.setAddCompletionChar(false)
+
+        val tail = editor.caretModel.offset
+
+        // Establish a balanced '<...>' right after the operator, reusing as much as the user has already written.
+        val angleBrackets = establishAngleBrackets(document, tail)
+
+        // Establish the parentheses right after the '>'.
+        val parenOffset = angleBrackets.end + 1
+        val insertedParentheses = document.charsSequence.getOrNull(parenOffset) != '('
+        if (insertedParentheses) document.insertString(parenOffset, "()")
+        val emptyParentheses = document.charsSequence.getOrNull(parenOffset + 1) == ')'
+
+        val tracker = TabOutScopesTracker.getInstance()
+        if (angleBrackets.isEmpty) {
+            // The type argument has yet to be written: place the caret inside the '<>' and make tab jump behind the
+            // opening parenthesis, regardless of how much type text has been typed by then.
+            editor.caretModel.moveToOffset(angleBrackets.start + 1)
+            tracker.registerEmptyScope(editor, angleBrackets.start + 1, parenOffset + 1)
+            // A second scope lets a final tab escape the parentheses. It has to span both pairs: the tracker discards
+            // any scope that is edited around, so only a scope containing the type argument survives it being typed.
+            if (emptyParentheses) tracker.registerScopeRange(editor, angleBrackets.start + 1, parenOffset + 1)
+        } else if (insertedParentheses || angleBrackets.insertedClosing) {
+            // The type argument is complete after this insertion: continue with the arguments.
+            editor.caretModel.moveToOffset(parenOffset + 1)
+            if (emptyParentheses) tracker.registerEmptyScope(editor, parenOffset + 1)
+        }
+        // Otherwise everything existed already; leave the caret behind the operator.
+    }
+}
+
+private fun bangOperatorLookupElement(operator: TableGenBangOperator) =
+    LookupElementBuilder.create(operator.operatorName).bold().withInsertHandler(
+        // The platform handler suffices for operators taking only parentheses.
+        if (operator.requiresTypeArgument) TypeAndArgumentsInsertHandler
+        else ParenthesesInsertHandler.WITH_PARAMETERS
+    )
+
+/**
+ * Completion for every bang operator known to the plugin, offered as soon as the '!' starting one has been typed.
+ */
+internal class TableGenBangOperatorCompletionContributor : CompletionContributor(), DumbAware {
+    init {
+        extend(
+            CompletionType.BASIC,
+            // A '!' followed by the completion's dummy identifier lexes as a generic bang operator token, regardless of
+            // which operator the user is about to type.
+            psiElement(BANG_OPERATOR).withParent(TableGenBangOperatorValueNode::class.java),
+            object : CompletionProvider<CompletionParameters>() {
+                override fun addCompletions(
+                    parameters: CompletionParameters,
+                    context: ProcessingContext,
+                    result: CompletionResultSet
+                ) {
+                    // The default prefix ends at the '!' as it is not an identifier character, leaving a prefix that no
+                    // operator name can ever match. Use the operator token up to the caret instead.
+                    val position = parameters.position
+                    val operators =
+                        result.withPrefixMatcher(position.text.substring(0, parameters.offset - position.startOffset))
+
+                    TableGenBangOperator.entries.forEach {
+                        operators.addElement(bangOperatorLookupElement(it))
+                    }
+                }
+            }
+        )
+    }
+}

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/completion/TableGenKeywordCompletionContributor.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/completion/TableGenKeywordCompletionContributor.kt
@@ -4,6 +4,7 @@ import com.github.zero9178.mlirods.language.psi.TableGenFile
 import com.github.zero9178.mlirods.language.generated.TableGenTypes.IDENTIFIER
 import com.github.zero9178.mlirods.language.generated.psi.*
 import com.intellij.codeInsight.completion.*
+import com.intellij.codeInsight.editorActions.TabOutScopesTracker
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.util.Key
@@ -157,8 +158,18 @@ internal class TableGenKeywordCompletionContributor : CompletionContributor(), D
                 ) {
                     TYPE_START_ANGLED.forEach {
                         result.addElement(keywordLookupElement(it).withInsertHandler { c, l ->
-                            c.document.insertString(c.tailOffset, "<>")
-                            c.editor.caretModel.moveCaretRelatively(1, 0, false, false, false)
+                            // A '<' the completion was selected with is established by this handler already and must
+                            // not be typed into the brackets the caret is placed in.
+                            if (c.completionChar == '<') c.setAddCompletionChar(false)
+
+                            val editor = c.editor
+                            val angleBrackets = establishAngleBrackets(editor.document, editor.caretModel.offset)
+                            // Enter the brackets if their content has yet to be written; otherwise leave the caret
+                            // behind the keyword.
+                            if (angleBrackets.isEmpty) {
+                                editor.caretModel.moveToOffset(angleBrackets.start + 1)
+                                TabOutScopesTracker.getInstance().registerEmptyScopeAtCaret(editor)
+                            }
                         })
                     }
                 }

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/completion/Util.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/completion/Util.kt
@@ -8,11 +8,59 @@ import com.github.zero9178.mlirods.language.stubs.disallowTreeLoading
 import com.intellij.codeInsight.AutoPopupController
 import com.intellij.codeInsight.completion.InsertHandler
 import com.intellij.codeInsight.completion.InsertionContext
+import com.intellij.codeInsight.editorActions.TabOutScopesTracker
 import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.EditorModificationUtilEx
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNamedElement
+
+/**
+ * The end of the type argument starting with the '<' at [start]: the offset of the matching '>', or, if the '<' is not
+ * followed by one, the offset the missing '>' has to be inserted at, which is the first character that cannot be part
+ * of a type. A type never spans multiple lines.
+ */
+private fun typeArgumentEnd(chars: CharSequence, start: Int): Int {
+    var depth = 1
+    for (i in start + 1..<chars.length) {
+        val c = chars[i]
+        when {
+            c == '<' -> depth++
+            c == '>' -> if (--depth == 0) return i
+            c == '\n' -> return i
+            !c.isLetterOrDigit() && c != '_' && c != ',' && !c.isWhitespace() -> return i
+        }
+    }
+    return chars.length
+}
+
+/**
+ * A balanced '<...>' established by [establishAngleBrackets]. [start] and [end] are the offsets of the '<' and '>'.
+ * [insertedClosing] is set if the '>' had to be inserted rather than being reused.
+ */
+internal class AngleBrackets(val start: Int, val end: Int, val insertedClosing: Boolean) {
+    /**
+     * Whether there is no text between the brackets yet.
+     */
+    val isEmpty get() = end == start + 1
+}
+
+/**
+ * Establishes a balanced '<...>' holding a type argument at [offset], reusing as much as the user has already written:
+ * an existing '<' is kept and only closed with a '>' if the type text following it lacks one; without an existing '<'
+ * an empty pair is inserted.
+ */
+internal fun establishAngleBrackets(document: Document, offset: Int): AngleBrackets {
+    if (document.charsSequence.getOrNull(offset) == '<') {
+        val end = typeArgumentEnd(document.charsSequence, offset)
+        val insertedClosing = document.charsSequence.getOrNull(end) != '>'
+        if (insertedClosing) document.insertString(end, ">")
+        return AngleBrackets(offset, end, insertedClosing)
+    }
+    document.insertString(offset, "<>")
+    return AngleBrackets(offset, offset + 1, insertedClosing = true)
+}
 
 private class ClassAngleBracketsInsertHandler(private val identifier: PsiElement) : InsertHandler<LookupElement> {
     override fun handleInsert(
@@ -37,16 +85,25 @@ private class ClassAngleBracketsInsertHandler(private val identifier: PsiElement
             else -> return@disallowTreeLoading
         }
 
+        // A '<' the completion was selected with is established by this handler already and must not be typed into the
+        // brackets the caret is placed in.
+        if (context.completionChar == '<') context.setAddCompletionChar(false)
+
         val editor = context.editor
         val document = editor.document
         val offset = editor.caretModel.offset
-        // Don't insert brackets if they are already there!
-        if (offset < document.textLength && document.charsSequence[offset] == '<')
-            return@disallowTreeLoading
+        if (document.charsSequence.getOrNull(offset) == '<') {
+            // Enter brackets the user has already written if they are still empty and the class has template arguments
+            // to fill in. Unlike a type argument, filled or unclosed brackets are left alone: template arguments are
+            // arbitrary values, whose end cannot reliably be scanned for.
+            if (!hasParams || document.charsSequence.getOrNull(offset + 1) != '>') return@disallowTreeLoading
+            editor.caretModel.moveToOffset(offset + 1)
+        } else {
+            EditorModificationUtilEx.insertStringAtCaret(editor, "<>", false, if (hasParams) 1 else 2)
+            if (!hasParams) return@disallowTreeLoading
+        }
 
-        EditorModificationUtilEx.insertStringAtCaret(editor, "<>", false, if (hasParams) 1 else 2)
-
-        if (!hasParams) return@disallowTreeLoading
+        TabOutScopesTracker.getInstance().registerEmptyScopeAtCaret(editor)
 
         // Invoke parameters popup.
         AutoPopupController.getInstance(context.project)

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/insertion/TableGenTypedHandlerDelegate.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/insertion/TableGenTypedHandlerDelegate.kt
@@ -3,6 +3,7 @@ package com.github.zero9178.mlirods.language.insertion
 import com.github.zero9178.mlirods.language.STRING_LITERALS
 import com.github.zero9178.mlirods.language.TableGenFileType
 import com.github.zero9178.mlirods.language.generated.TableGenTypes.BLOCK_STRING_LITERAL
+import com.intellij.codeInsight.AutoPopupController
 import com.intellij.codeInsight.editorActions.TypedHandlerDelegate
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
@@ -11,6 +12,19 @@ import com.intellij.psi.util.elementType
 import com.intellij.psi.util.startOffset
 
 internal class TableGenTypedHandlerDelegate : TypedHandlerDelegate() {
+    override fun checkAutoPopup(
+        charTyped: Char, project: Project, editor: Editor, file: PsiFile
+    ): Result {
+        if (file.fileType != TableGenFileType.INSTANCE) return Result.CONTINUE
+
+        if (charTyped != '!') return Result.CONTINUE
+
+        // A '!' starts a bang operator, but as it is not an identifier character the platform would not consider it
+        // worth showing completion for on its own.
+        AutoPopupController.getInstance(project).scheduleAutoPopup(editor)
+        return Result.STOP
+    }
+
     override fun charTyped(
         c: Char, project: Project, editor: Editor, file: PsiFile
     ): Result {

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenBangOperator.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/TableGenBangOperator.kt
@@ -1,16 +1,21 @@
 package com.github.zero9178.mlirods.language.psi
 
 /**
- * Enumeration of the bang operators parsed as a generic 'bang_operator_value_node'.
- *
- * This is the set of bang operators known to TableGen, minus those that have their own dedicated token and PSI node and
- * are therefore parsed specially.
+ * Enumeration of all bang operators known to TableGen.
  *
  * The [operatorName] is the full operator token text including the leading '!'. [arity] is the range of allowed operand
  * counts (the values inside the parentheses; a leading '<type>' is not an operand). Operators whose arguments are folded
  * left-associatively (e.g. '!add') accept any number of operands greater than or equal to two.
  */
-enum class TableGenBangOperator(val operatorName: String, val arity: IntRange) {
+enum class TableGenBangOperator(
+    val operatorName: String,
+    val arity: IntRange,
+    /**
+     * Whether the operator requires a '<type>' argument between the operator and its operands. Operators that merely
+     * allow one do not set this.
+     */
+    val requiresTypeArgument: Boolean = false,
+) {
     // Comparison.
     EQ("!eq", 2..2),
     NE("!ne", 2..2),
@@ -75,6 +80,20 @@ enum class TableGenBangOperator(val operatorName: String, val arity: IntRange) {
     SETDAGARG("!setdagarg", 3..3),
     GETDAGNAME("!getdagname", 2..2),
     SETDAGNAME("!setdagname", 3..3),
+
+    // Operators parsed into a dedicated Psi node.
+    CAST("!cast", 1..1, requiresTypeArgument = true),
+
+    // The operands of '!cond' are 'condition : value' clauses, of which at least one is required.
+    COND("!cond", 1..Int.MAX_VALUE),
+
+    // '!switch' takes the value to match on, at least one 'case : value' clause and the mandatory default value.
+    SWITCH("!switch", 3..Int.MAX_VALUE),
+
+    FOREACH("!foreach", 3..3),
+    FOLDL("!foldl", 5..5),
+    FILTER("!filter", 3..3),
+    SORT("!sort", 3..3),
     ;
 
     companion object {

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenValueNodeEx.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/psi/impl/TableGenValueNodeEx.kt
@@ -148,7 +148,8 @@ interface TableGenBangOperatorValueNodeEx : TableGenValueNodeEx {
     val operatorName: String
 
     /**
-     * The known bang operator this node uses, or null if [operatorName] is not a recognized bang operator.
+     * The known bang operator this node uses, or null if [operatorName] is not a recognized bang operator. Only
+     * operators without a dedicated Psi node can ever be returned.
      */
     val operator: TableGenBangOperator?
         get() = TableGenBangOperator.fromOperatorName(operatorName)

--- a/src/main/kotlin/com/github/zero9178/mlirods/language/types/TableGenTypeOfValueVisitor.kt
+++ b/src/main/kotlin/com/github/zero9178/mlirods/language/types/TableGenTypeOfValueVisitor.kt
@@ -246,6 +246,9 @@ object TableGenTypeOfValueVisitor : TableGenVisitor<TableGenType>() {
             LISTCONCAT, LISTREMOVE -> operands.map { it.type }.commonType() as? TableGenListType
                 ?: TableGenUnknownType
 
+            // These are parsed into their own Psi node and have their type computed by the corresponding visit method.
+            CAST, COND, SWITCH, FOREACH, FOLDL, FILTER, SORT -> TableGenUnknownType
+
             LISTFLATTEN -> {
                 val elementType = (operands.firstOrNull()?.type as? TableGenListType)?.elementType
                     ?: return TableGenUnknownType

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -81,6 +81,8 @@
         <completion.contributor language="TableGen"
                                 implementationClass="com.github.zero9178.mlirods.language.completion.TableGenKeywordCompletionContributor"/>
         <completion.contributor language="TableGen"
+                                implementationClass="com.github.zero9178.mlirods.language.completion.TableGenBangOperatorCompletionContributor"/>
+        <completion.contributor language="TableGen"
                                 implementationClass="com.github.zero9178.mlirods.language.completion.TableGenInterFileCompletionContributor"/>
         <completion.contributor language="TableGen"
                                 implementationClass="com.github.zero9178.mlirods.language.completion.TableGenClassReferenceCompletionContributor"/>

--- a/src/test/kotlin/com/github/zero9178/mlirods/AutoPopupTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/AutoPopupTest.kt
@@ -1,0 +1,18 @@
+package com.github.zero9178.mlirods
+
+import com.intellij.testFramework.fixtures.CompletionAutoPopupTestCase
+
+class AutoPopupTest : CompletionAutoPopupTestCase() {
+    fun `test bang operator autopopup`() {
+        myFixture.configureByText(
+            "test.td", """
+            defvar test = <caret>;
+        """.trimIndent()
+        )
+
+        type("!")
+
+        val lookup = requireNotNull(lookup) { "typing '!' did not pop up completion" }
+        assertContainsElements(lookup.items.map { it.lookupString }, "!add", "!cond")
+    }
+}

--- a/src/test/kotlin/com/github/zero9178/mlirods/CompletionTest.kt
+++ b/src/test/kotlin/com/github/zero9178/mlirods/CompletionTest.kt
@@ -1,7 +1,13 @@
 package com.github.zero9178.mlirods
 
+import com.github.zero9178.mlirods.language.BANG_OPERATORS
+import com.github.zero9178.mlirods.language.generated.TableGenTypes
+import com.github.zero9178.mlirods.language.psi.TableGenBangOperator
 import com.github.zero9178.mlirods.model.IncludePaths
+import com.intellij.codeInsight.lookup.impl.LookupImpl
+import com.intellij.openapi.actionSystem.IdeActions
 import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.editor.ex.EditorSettingsExternalizable
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.testFramework.DumbModeTestUtils
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
@@ -24,6 +30,199 @@ class CompletionTest : BasePlatformTestCase() {
             defvar test = !foreach(i, <caret>, i);
         """.trimIndent(), "values", doesNotContain = listOf("i")
     )
+
+    fun `test bang operator completion`() = doTest(
+        """
+            defvar test = !<caret>;
+        """.trimIndent(),
+        "!add",
+        "!eq",
+        "!getdagarg",
+        "!cast",
+        "!cond",
+        "!filter",
+        "!foldl",
+        "!foreach",
+        "!sort",
+        "!switch",
+    )
+
+    /**
+     * Every operator with a dedicated token has to be part of [TableGenBangOperator] as well to be offered for
+     * completion.
+     */
+    fun `test bang operator completion contains every dedicated operator`() = doTest(
+        """
+            defvar test = !<caret>;
+        """.trimIndent(),
+        *BANG_OPERATORS.types.filter { it != TableGenTypes.BANG_OPERATOR }.map { it.toString() }.toTypedArray()
+    )
+
+    fun `test bang operator completion at eof`() = doTest(
+        """
+            defvar test = !<caret>
+        """.trimIndent(), "!add", "!cond"
+    )
+
+    fun `test bang operator completion in nested value`() = doTest(
+        """
+            defvar test = [1, !<caret>];
+        """.trimIndent(), "!add", "!cond"
+    )
+
+    fun `test bang operator completion typing`() = doTestTyping(
+        """
+            defvar test = !listrem<caret>;
+        """.trimIndent(), """
+            defvar test = !listremove(<caret>);
+        """.trimIndent()
+    )
+
+    fun `test bang operator completion keeps existing parentheses`() = doTestTyping(
+        """
+            defvar test = !listrem<caret>(1, 2);
+        """.trimIndent(), """
+            defvar test = !listremove(<caret>1, 2);
+        """.trimIndent()
+    )
+
+    fun `test cast operator completion typing`() = doTestTyping(
+        """
+            defvar test = !cas<caret>;
+        """.trimIndent(), """
+            defvar test = !cast<<caret>>();
+        """.trimIndent()
+    )
+
+    fun `test cast operator completion adds type argument to existing parentheses`() = doTestTyping(
+        """
+            defvar test = !cas<caret>(1);
+        """.trimIndent(), """
+            defvar test = !cast<<caret>>(1);
+        """.trimIndent()
+    )
+
+    fun `test cast operator completion keeps existing type argument`() = doTestTyping(
+        """
+            defvar test = !cas<caret><int>(1);
+        """.trimIndent(), """
+            defvar test = !cast<caret><int>(1);
+        """.trimIndent()
+    )
+
+    fun `test cast operator completion adds parentheses to existing type argument`() = doTestTyping(
+        """
+            defvar test = !cas<caret><int>;
+        """.trimIndent(), """
+            defvar test = !cast<int>(<caret>);
+        """.trimIndent()
+    )
+
+    fun `test cast operator completion enters existing empty type argument`() = doTestTyping(
+        """
+            defvar test = !cas<caret><>(1);
+        """.trimIndent(), """
+            defvar test = !cast<<caret>>(1);
+        """.trimIndent()
+    )
+
+    fun `test cast operator completion closes unbalanced type argument`() = doTestTyping(
+        """
+            defvar test = !cas<caret><;
+        """.trimIndent(), """
+            defvar test = !cast<<caret>>();
+        """.trimIndent()
+    )
+
+    fun `test cast operator completion closes unbalanced type argument with parentheses`() = doTestTyping(
+        """
+            defvar test = !cas<caret><int(1);
+        """.trimIndent(), """
+            defvar test = !cast<int>(<caret>1);
+        """.trimIndent()
+    )
+
+    fun `test bang operator completion allows tabbing out of parentheses`() = doTestTyping(
+        """
+            defvar test = !ad<caret>;
+        """.trimIndent(), """
+            defvar test = !add(1, 2)<caret>;
+        """.trimIndent()
+    ) {
+        myFixture.type("1, 2")
+        myFixture.performEditorAction(IdeActions.ACTION_BRACE_OR_QUOTE_OUT)
+    }
+
+    fun `test cast operator completion allows tabbing from type argument into parentheses`() = doTestTyping(
+        """
+            defvar test = !cas<caret>;
+        """.trimIndent(), """
+            defvar test = !cast<int>(<caret>);
+        """.trimIndent()
+    ) {
+        myFixture.type("int")
+        myFixture.performEditorAction(IdeActions.ACTION_BRACE_OR_QUOTE_OUT)
+    }
+
+    fun `test cast operator completion allows tabbing into existing parentheses`() = doTestTyping(
+        """
+            defvar test = !cas<caret>(1);
+        """.trimIndent(), """
+            defvar test = !cast<int>(<caret>1);
+        """.trimIndent()
+    ) {
+        myFixture.type("int")
+        myFixture.performEditorAction(IdeActions.ACTION_BRACE_OR_QUOTE_OUT)
+    }
+
+    fun `test cast operator completion selected with angle bracket`() = doTestSelectWithChar(
+        """
+            defvar test = !c<caret>;
+        """.trimIndent(), "!cast", '<', """
+            defvar test = !cast<<caret>>();
+        """.trimIndent()
+    )
+
+    fun `test cast operator completion without automatic parentheses`() {
+        val settings = EditorSettingsExternalizable.getInstance()
+        val previous = settings.isInsertParenthesesAutomatically
+        settings.isInsertParenthesesAutomatically = false
+        try {
+            doTestTyping(
+                """
+                    defvar test = !cas<caret>;
+                """.trimIndent(), """
+                    defvar test = !cast<caret>;
+                """.trimIndent()
+            )
+        } finally {
+            settings.isInsertParenthesesAutomatically = previous
+        }
+    }
+
+    fun `test cast operator completion allows tabbing through both empty pairs`() = doTestTyping(
+        """
+            defvar test = !cas<caret>;
+        """.trimIndent(), """
+            defvar test = !cast<>()<caret>;
+        """.trimIndent()
+    ) {
+        myFixture.performEditorAction(IdeActions.ACTION_BRACE_OR_QUOTE_OUT)
+        myFixture.performEditorAction(IdeActions.ACTION_BRACE_OR_QUOTE_OUT)
+    }
+
+    fun `test cast operator completion allows tabbing out after writing both pairs`() = doTestTyping(
+        """
+            defvar test = !cas<caret>;
+        """.trimIndent(), """
+            defvar test = !cast<int>(1)<caret>;
+        """.trimIndent()
+    ) {
+        myFixture.type("int")
+        myFixture.performEditorAction(IdeActions.ACTION_BRACE_OR_QUOTE_OUT)
+        myFixture.type("1")
+        myFixture.performEditorAction(IdeActions.ACTION_BRACE_OR_QUOTE_OUT)
+    }
 
     fun `test field access lookup`() = doTest(
         """
@@ -238,6 +437,57 @@ class CompletionTest : BasePlatformTestCase() {
         """.trimIndent()
     )
 
+    fun `test list completion keeps existing type argument`() = doTestTyping(
+        """
+        class A {
+            lis<caret><int> x;
+        }
+    """.trimIndent(), """
+        class A {
+            list<caret><int> x;
+        }
+        """.trimIndent()
+    )
+
+    fun `test list completion enters existing empty type argument`() = doTestTyping(
+        """
+        class A {
+            lis<caret><> x;
+        }
+    """.trimIndent(), """
+        class A {
+            list<<caret>> x;
+        }
+        """.trimIndent()
+    )
+
+    fun `test list completion allows tabbing out of type argument`() = doTestTyping(
+        """
+        class A {
+            lis<caret>
+        }
+    """.trimIndent(), """
+        class A {
+            list<int><caret>
+        }
+        """.trimIndent()
+    ) {
+        myFixture.type("int")
+        myFixture.performEditorAction(IdeActions.ACTION_BRACE_OR_QUOTE_OUT)
+    }
+
+    fun `test bits completion selected with angle bracket`() = doTestSelectWithChar(
+        """
+        class A {
+            bit<caret>
+        }
+    """.trimIndent(), "bits", '<', """
+        class A {
+            bits<<caret>>
+        }
+        """.trimIndent()
+    )
+
     fun `test space after field`() = doTestTyping(
         """
         class A {
@@ -316,6 +566,47 @@ class CompletionTest : BasePlatformTestCase() {
         )
     }
 
+    fun `test class completion enters existing empty brackets`() = doTestTyping(
+        """
+            class ALong<int i>;
+
+            def : A<caret><>;
+        """.trimIndent(), """
+            class ALong<int i>;
+
+            def : ALong<<caret>>;
+        """.trimIndent()
+    )
+
+    fun `test class completion selected with angle bracket`() = doTestSelectWithChar(
+        """
+            class ALong<int i>;
+            class AOther<int i>;
+
+            def : A<caret>;
+        """.trimIndent(), "ALong", '<', """
+            class ALong<int i>;
+            class AOther<int i>;
+
+            def : ALong<<caret>>;
+        """.trimIndent()
+    )
+
+    fun `test class completion allows tabbing out of brackets`() = doTestTyping(
+        """
+            class ALong<int i>;
+
+            def : A<caret>;
+        """.trimIndent(), """
+            class ALong<int i>;
+
+            def : ALong<1><caret>;
+        """.trimIndent()
+    ) {
+        myFixture.type("1")
+        myFixture.performEditorAction(IdeActions.ACTION_BRACE_OR_QUOTE_OUT)
+    }
+
 
     fun `test class cross file access lookup`() = doCrossFileTestTyping(
         """
@@ -365,12 +656,30 @@ class CompletionTest : BasePlatformTestCase() {
         assertDoesntContain(collection, doesNotContain)
     }
 
-    private fun doTestTyping(source: String, expectedText: String) {
+    private fun doTestTyping(source: String, expectedText: String, afterCompletion: () -> Unit = {}) {
         myFixture.configureByText(
             "test.td", source
         )
 
         myFixture.completeBasicAllCarets(null)
+        afterCompletion()
+        myFixture.checkResult(expectedText)
+    }
+
+    /**
+     * Completes at the caret in [source], selecting [lookupString] from the lookup by typing [completionChar].
+     */
+    private fun doTestSelectWithChar(
+        source: String, lookupString: String, completionChar: Char, expectedText: String
+    ) {
+        myFixture.configureByText(
+            "test.td", source
+        )
+
+        myFixture.completeBasic()
+        val lookup = myFixture.lookup as LookupImpl
+        lookup.currentItem = myFixture.lookupElements!!.first { it.lookupString == lookupString }
+        myFixture.finishLookup(completionChar)
         myFixture.checkResult(expectedText)
     }
 


### PR DESCRIPTION
While builtins, the list of bang operators is non-trivial and code completion also helps users finding the right ones that they only vaguely remember.

Additionally add logic for inserting parentheses afterward if not present, and optionally angle brackets for types if needed. Users can navigate between the inserted delimiters even after typing by pressing tab.

This was also backported to existing code completion contributors.